### PR TITLE
Introduces IdentityPlugin with initial interface for extensions use-cases

### DIFF
--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -165,13 +165,20 @@ public class ExtensionsManager {
         SettingsModule settingsModule,
         TransportService transportService,
         ClusterService clusterService,
+        IdentityService identityService,
         Settings initialEnvironmentSettings,
         NodeClient client
     ) {
-        this.restActionsRequestHandler = new RestActionsRequestHandler(actionModule.getRestController(), extensionIdMap, transportService);
+        this.restActionsRequestHandler = new RestActionsRequestHandler(
+            actionModule.getRestController(),
+            extensionIdMap,
+            transportService,
+            identityService
+        );
         this.customSettingsRequestHandler = new CustomSettingsRequestHandler(settingsModule);
         this.transportService = transportService;
         this.clusterService = clusterService;
+        this.identityService = identityService;
         this.environmentSettings = initialEnvironmentSettings;
         this.addSettingsUpdateConsumerRequestHandler = new AddSettingsUpdateConsumerRequestHandler(
             clusterService,

--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -56,6 +56,7 @@ import org.opensearch.extensions.rest.RegisterRestActionsRequest;
 import org.opensearch.extensions.rest.RestActionsRequestHandler;
 import org.opensearch.extensions.settings.CustomSettingsRequestHandler;
 import org.opensearch.extensions.settings.RegisterCustomSettingsRequest;
+import org.opensearch.identity.IdentityService;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.IndicesModuleRequest;
@@ -114,6 +115,7 @@ public class ExtensionsManager {
     private CustomSettingsRequestHandler customSettingsRequestHandler;
     private TransportService transportService;
     private ClusterService clusterService;
+    private IdentityService identityService;
     private Settings environmentSettings;
     private AddSettingsUpdateConsumerRequestHandler addSettingsUpdateConsumerRequestHandler;
     private NodeClient client;
@@ -661,6 +663,10 @@ public class ExtensionsManager {
 
     public ClusterService getClusterService() {
         return clusterService;
+    }
+
+    public void setIdentityService(IdentityService identityService) {
+        this.identityService = identityService;
     }
 
     public static String getRequestExtensionRegisterRestActions() {

--- a/server/src/main/java/org/opensearch/extensions/rest/RestActionsRequestHandler.java
+++ b/server/src/main/java/org/opensearch/extensions/rest/RestActionsRequestHandler.java
@@ -10,6 +10,7 @@ package org.opensearch.extensions.rest;
 
 import org.opensearch.extensions.AcknowledgedResponse;
 import org.opensearch.extensions.DiscoveryExtensionNode;
+import org.opensearch.identity.IdentityService;
 import org.opensearch.rest.RestController;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.transport.TransportResponse;
@@ -28,6 +29,8 @@ public class RestActionsRequestHandler {
     private final Map<String, DiscoveryExtensionNode> extensionIdMap;
     private final TransportService transportService;
 
+    private final IdentityService identityService;
+
     /**
      * Instantiates a new REST Actions Request Handler using the Node's RestController.
      *
@@ -38,11 +41,13 @@ public class RestActionsRequestHandler {
     public RestActionsRequestHandler(
         RestController restController,
         Map<String, DiscoveryExtensionNode> extensionIdMap,
-        TransportService transportService
+        TransportService transportService,
+        IdentityService identityService
     ) {
         this.restController = restController;
         this.extensionIdMap = extensionIdMap;
         this.transportService = transportService;
+        this.identityService = identityService;
     }
 
     /**
@@ -54,7 +59,7 @@ public class RestActionsRequestHandler {
      */
     public TransportResponse handleRegisterRestActionsRequest(RegisterRestActionsRequest restActionsRequest) throws Exception {
         DiscoveryExtensionNode discoveryExtensionNode = extensionIdMap.get(restActionsRequest.getUniqueId());
-        RestHandler handler = new RestSendToExtensionAction(restActionsRequest, discoveryExtensionNode, transportService);
+        RestHandler handler = new RestSendToExtensionAction(restActionsRequest, discoveryExtensionNode, transportService, identityService);
         restController.registerHandler(handler);
         return new AcknowledgedResponse(true);
     }

--- a/server/src/main/java/org/opensearch/identity/IdentityService.java
+++ b/server/src/main/java/org/opensearch/identity/IdentityService.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.identity;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.OpenSearchException;
+import org.opensearch.identity.noop.NoopIdentityPlugin;
+import java.util.List;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.plugins.IdentityPlugin;
+import java.util.stream.Collectors;
+
+/**
+ * Identity and access control for OpenSearch.
+ *
+ * @opensearch.experimental
+ * */
+public class IdentityService {
+    private static final Logger logger = LogManager.getLogger(IdentityService.class);
+
+    private final Settings settings;
+    private final IdentityPlugin identityPlugin;
+
+    public IdentityService(final Settings settings, final List<IdentityPlugin> identityPlugins) {
+        this.settings = settings;
+
+        if (identityPlugins.size() == 0) {
+            identityPlugin = new NoopIdentityPlugin();
+        } else if (identityPlugins.size() == 1) {
+            identityPlugin = identityPlugins.get(0);
+        } else {
+            throw new OpenSearchException(
+                "Multiple identity plugins are not supported, found: "
+                    + identityPlugins.stream().map(Object::getClass).map(Class::getName).collect(Collectors.joining(","))
+            );
+        }
+
+        logger.info("Identity module loaded with " + identityPlugin.getClass().getName());
+        logger.info("Current subject " + getSubject());
+    }
+
+    /**
+     * Gets the current subject
+     */
+    public Subject getSubject() {
+        return identityPlugin.getSubject();
+    }
+
+    /**
+     * Gets the token manager
+     */
+    public TokenManager getTokenManager() {
+        return identityPlugin.getTokenManager();
+    }
+}

--- a/server/src/main/java/org/opensearch/identity/NamedPrincipal.java
+++ b/server/src/main/java/org/opensearch/identity/NamedPrincipal.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.identity;
+
+import java.security.Principal;
+import java.util.Objects;
+
+/**
+ * Create a principal from a string
+ *
+ * @opensearch.experimental
+ */
+public class NamedPrincipal implements Principal {
+
+    private final String name;
+
+    /**
+     * Creates a principal for an identity specified as a string
+     * @param name A persistent string that represent an identity
+     */
+    public NamedPrincipal(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        final Principal that = (Principal) obj;
+        return Objects.equals(name, that.getName());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public String toString() {
+        return "StringPrincipal(" + "name=" + name + ")";
+    }
+}

--- a/server/src/main/java/org/opensearch/identity/Principals.java
+++ b/server/src/main/java/org/opensearch/identity/Principals.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.identity;
+
+import java.security.Principal;
+
+/**
+ * Available OpenSearch internal principals
+ *
+ * @opensearch.experimental
+ */
+public enum Principals {
+
+    /**
+     * Represents a principal which has not been authenticated
+     */
+    UNAUTHENTICATED(new NamedPrincipal("Unauthenticated")),
+    NONE(new NamedPrincipal("None"));
+
+    private final Principal principal;
+
+    Principals(final Principal principal) {
+        this.principal = principal;
+    }
+
+    /**
+     * Returns the underlying principal for this
+     */
+    public Principal getPrincipal() {
+        return principal;
+    }
+
+}

--- a/server/src/main/java/org/opensearch/identity/Subject.java
+++ b/server/src/main/java/org/opensearch/identity/Subject.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.identity;
+
+import java.security.Principal;
+
+/**
+ * An individual, process, or device that causes information to flow among objects or change to the system state.
+ *
+ * @opensearch.experimental
+ */
+public interface Subject {
+
+    /**
+     * Get the application-wide uniquely identifying principal
+     * */
+    Principal getPrincipal();
+
+    /**
+     * Login through an authentication token
+     * throws UnsupportedAuthenticationMethod
+     * throws InvalidAuthenticationToken
+     * throws SubjectNotFound
+     * throws SubjectDisabled
+     */
+    // TODO Uncomment login and make a richer interface to IdentityPlugin for authc and authz use-cases
+    // void login(final AuthToken token);
+
+    /**
+     * Method that returns whether the current subject of the running thread is authenticated
+     */
+    boolean isAuthenticated();
+}

--- a/server/src/main/java/org/opensearch/identity/TokenManager.java
+++ b/server/src/main/java/org/opensearch/identity/TokenManager.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.identity;
+
+import org.opensearch.OpenSearchSecurityException;
+import org.opensearch.identity.tokens.AuthToken;
+
+/**
+ * Interface for a token manager to issue Auth Tokens for a User
+ *
+ * @opensearch.experimental
+ */
+public interface TokenManager {
+    /**
+     * Issue an access token on-behalf-of authenticated user for a service to utilize to interact with
+     * the OpenSearch cluster on-behalf-of the original user
+     * */
+    AuthToken issueAccessTokenOnBehalfOfAuthenticatedUser(String extensionUniqueId) throws OpenSearchSecurityException;
+
+    /**
+     * Issue a refresh token on-behalf-of authenticated user for a service to refresh access tokens
+     * */
+    AuthToken issueRefreshTokenOnBehalfOfAuthenticatedUser(String extensionUniqueId) throws OpenSearchSecurityException;
+
+    /**
+     * Issue a service account token for an extension's service account
+     * */
+    AuthToken generateServiceAccountToken(String extensionUniqueId) throws OpenSearchSecurityException;
+}

--- a/server/src/main/java/org/opensearch/identity/noop/NoopIdentityPlugin.java
+++ b/server/src/main/java/org/opensearch/identity/noop/NoopIdentityPlugin.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.identity.noop;
+
+import org.opensearch.identity.TokenManager;
+import org.opensearch.plugins.IdentityPlugin;
+import org.opensearch.identity.Subject;
+
+/**
+ * Implementation of identity plugin that does not enforce authentication or authorization
+ *
+ * This class and related classes in this package will not return nulls or fail access checks
+ *
+ * @opensearch.internal
+ */
+public class NoopIdentityPlugin implements IdentityPlugin {
+
+    @Override
+    public Subject getSubject() {
+        return new NoopSubject();
+    }
+
+    @Override
+    public TokenManager getTokenManager() {
+        return new NoopTokenManager();
+    }
+
+}

--- a/server/src/main/java/org/opensearch/identity/noop/NoopSubject.java
+++ b/server/src/main/java/org/opensearch/identity/noop/NoopSubject.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.identity.noop;
+
+import java.security.Principal;
+import java.util.Objects;
+
+import org.opensearch.identity.Subject;
+import org.opensearch.identity.Principals;
+
+/**
+ * Implementation of subject that is always authenticated
+ *
+ * This class and related classes in this package will not return nulls or fail permissions checks
+ *
+ * @opensearch.internal
+ */
+public class NoopSubject implements Subject {
+
+    @Override
+    public Principal getPrincipal() {
+        return Principals.NONE.getPrincipal();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        Subject that = (Subject) obj;
+        return Objects.equals(getPrincipal(), that.getPrincipal());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getPrincipal());
+    }
+
+    @Override
+    public String toString() {
+        return "NoopSubject(principal=" + getPrincipal() + ")";
+    }
+
+    /**
+     * Logs the user in
+     */
+    // @Override
+    // public void login(AuthToken AuthToken) {
+    // // Do nothing as noop subject is always logged in
+    // }
+
+    @Override
+    public boolean isAuthenticated() {
+        return true;
+    }
+}

--- a/server/src/main/java/org/opensearch/identity/noop/NoopToken.java
+++ b/server/src/main/java/org/opensearch/identity/noop/NoopToken.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.identity.noop;
+
+import org.opensearch.identity.tokens.AuthToken;
+
+/**
+ * Implementation of an AuthToken that gives back an empty token
+ *
+ * @opensearch.experimental
+ */
+public class NoopToken extends AuthToken {
+    public NoopToken(String tokenValue) {
+        super(tokenValue);
+    }
+}

--- a/server/src/main/java/org/opensearch/identity/noop/NoopTokenManager.java
+++ b/server/src/main/java/org/opensearch/identity/noop/NoopTokenManager.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.identity.noop;
+
+import org.opensearch.OpenSearchSecurityException;
+import org.opensearch.identity.TokenManager;
+import org.opensearch.identity.tokens.AuthToken;
+
+/**
+ * Implementation of a TokenManager that gives back NoopTokens
+ *
+ * @opensearch.experimental
+ */
+public class NoopTokenManager implements TokenManager {
+    @Override
+    public AuthToken issueAccessTokenOnBehalfOfAuthenticatedUser(String extensionUniqueId) {
+        return new NoopToken("");
+    }
+
+    @Override
+    public AuthToken issueRefreshTokenOnBehalfOfAuthenticatedUser(String extensionUniqueId) {
+        return new NoopToken("");
+    }
+
+    @Override
+    public AuthToken generateServiceAccountToken(String extensionUniqueId) throws OpenSearchSecurityException {
+        return new NoopToken("");
+    }
+}

--- a/server/src/main/java/org/opensearch/identity/noop/package-info.java
+++ b/server/src/main/java/org/opensearch/identity/noop/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** Classes for the noop authentication in OpenSearch */
+package org.opensearch.identity.noop;

--- a/server/src/main/java/org/opensearch/identity/package-info.java
+++ b/server/src/main/java/org/opensearch/identity/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** Core identity and access controls for OpenSearch */
+package org.opensearch.identity;

--- a/server/src/main/java/org/opensearch/identity/tokens/AuthToken.java
+++ b/server/src/main/java/org/opensearch/identity/tokens/AuthToken.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.identity.tokens;
+
+/**
+ * Interface for all token formats to support to authenticate user such as UserName/Password tokens, Access tokens, and more.
+ *
+ * @opensearch.experimental
+ */
+public abstract class AuthToken {
+
+    private final String tokenValue;
+
+    public AuthToken(String tokenValue) {
+        this.tokenValue = tokenValue;
+    }
+
+    public String getTokenValue() {
+        return this.tokenValue;
+    }
+
+}

--- a/server/src/main/java/org/opensearch/identity/tokens/BearerToken.java
+++ b/server/src/main/java/org/opensearch/identity/tokens/BearerToken.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.identity.tokens;
+
+/**
+ * Class that represents a token used for HTTP Bearer Authentication
+ *
+ * Bearer tokens are passed in the HTTP Authorization header
+ *
+ * Authorization: Bearer {bearer_token}
+ *
+ * @opensearch.experimental
+ */
+public class BearerToken extends AuthToken {
+    public BearerToken(String tokenValue) {
+        super(tokenValue);
+    }
+}

--- a/server/src/main/java/org/opensearch/identity/tokens/package-info.java
+++ b/server/src/main/java/org/opensearch/identity/tokens/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** Classes for the authentication tokens in OpenSearch */
+package org.opensearch.identity.tokens;

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -875,6 +875,7 @@ public class Node implements Closeable {
                     settingsModule,
                     transportService,
                     clusterService,
+                    identityService,
                     environment.settings(),
                     client
                 );

--- a/server/src/main/java/org/opensearch/plugins/IdentityPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/IdentityPlugin.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugins;
+
+import org.opensearch.identity.Subject;
+import org.opensearch.identity.TokenManager;
+
+/**
+ * Plugin that provides identity and access control for OpenSearch
+ *
+ * @opensearch.experimental
+ */
+public interface IdentityPlugin {
+
+    /**
+     * Get the current subject
+     * */
+    public Subject getSubject();
+
+    /**
+     * Get the token manager
+     * */
+    public TokenManager getTokenManager();
+}

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
@@ -70,6 +70,7 @@ import org.opensearch.env.TestEnvironment;
 import org.opensearch.extensions.proto.ExtensionRequestProto;
 import org.opensearch.extensions.rest.RegisterRestActionsRequest;
 import org.opensearch.extensions.settings.RegisterCustomSettingsRequest;
+import org.opensearch.identity.IdentityService;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.analysis.AnalysisRegistry;
@@ -100,6 +101,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
     private RestController restController;
     private SettingsModule settingsModule;
     private ClusterService clusterService;
+    private IdentityService identityService;
     private NodeClient client;
     private MockNioTransport transport;
     private Path extensionDir;
@@ -823,6 +825,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             settingsModule,
             mockTransportService,
             clusterService,
+            identityService,
             settings,
             client
         );
@@ -903,6 +906,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             settingsModule,
             transportService,
             clusterService,
+            identityService,
             settings,
             client
         );

--- a/server/src/test/java/org/opensearch/extensions/rest/RestSendToExtensionActionTests.java
+++ b/server/src/test/java/org/opensearch/extensions/rest/RestSendToExtensionActionTests.java
@@ -32,6 +32,8 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.common.util.PageCacheRecycler;
 import org.opensearch.extensions.DiscoveryExtensionNode;
+import org.opensearch.identity.IdentityService;
+import org.opensearch.identity.noop.NoopIdentityPlugin;
 import org.opensearch.indices.breaker.NoneCircuitBreakerService;
 import org.opensearch.rest.RestHandler.Route;
 import org.opensearch.rest.RestRequest.Method;
@@ -45,6 +47,7 @@ import org.opensearch.transport.nio.MockNioTransport;
 public class RestSendToExtensionActionTests extends OpenSearchTestCase {
 
     private TransportService transportService;
+    private IdentityService identityService;
     private MockNioTransport transport;
     private DiscoveryExtensionNode discoveryExtensionNode;
     private final ThreadPool threadPool = new TestThreadPool(RestSendToExtensionActionTests.class.getSimpleName());
@@ -86,6 +89,8 @@ public class RestSendToExtensionActionTests extends OpenSearchTestCase {
             Version.fromString("3.0.0"),
             Collections.emptyList()
         );
+
+        identityService = new IdentityService(Settings.EMPTY, List.of(new NoopIdentityPlugin()));
     }
 
     @Override
@@ -105,7 +110,8 @@ public class RestSendToExtensionActionTests extends OpenSearchTestCase {
         RestSendToExtensionAction restSendToExtensionAction = new RestSendToExtensionAction(
             registerRestActionRequest,
             discoveryExtensionNode,
-            transportService
+            transportService,
+            identityService
         );
 
         assertEquals("send_to_extension_action", restSendToExtensionAction.getName());
@@ -136,7 +142,8 @@ public class RestSendToExtensionActionTests extends OpenSearchTestCase {
         RestSendToExtensionAction restSendToExtensionAction = new RestSendToExtensionAction(
             registerRestActionRequest,
             discoveryExtensionNode,
-            transportService
+            transportService,
+            identityService
         );
 
         Map<String, List<String>> headers = new HashMap<>();
@@ -162,7 +169,7 @@ public class RestSendToExtensionActionTests extends OpenSearchTestCase {
         );
         expectThrows(
             IllegalArgumentException.class,
-            () -> new RestSendToExtensionAction(registerRestActionRequest, discoveryExtensionNode, transportService)
+            () -> new RestSendToExtensionAction(registerRestActionRequest, discoveryExtensionNode, transportService, identityService)
         );
     }
 
@@ -174,7 +181,7 @@ public class RestSendToExtensionActionTests extends OpenSearchTestCase {
         );
         expectThrows(
             IllegalArgumentException.class,
-            () -> new RestSendToExtensionAction(registerRestActionRequest, discoveryExtensionNode, transportService)
+            () -> new RestSendToExtensionAction(registerRestActionRequest, discoveryExtensionNode, transportService, identityService)
         );
     }
 
@@ -186,7 +193,7 @@ public class RestSendToExtensionActionTests extends OpenSearchTestCase {
         );
         expectThrows(
             IllegalArgumentException.class,
-            () -> new RestSendToExtensionAction(registerRestActionRequest, discoveryExtensionNode, transportService)
+            () -> new RestSendToExtensionAction(registerRestActionRequest, discoveryExtensionNode, transportService, identityService)
         );
     }
 
@@ -198,7 +205,7 @@ public class RestSendToExtensionActionTests extends OpenSearchTestCase {
         );
         expectThrows(
             IllegalArgumentException.class,
-            () -> new RestSendToExtensionAction(registerRestActionRequest, discoveryExtensionNode, transportService)
+            () -> new RestSendToExtensionAction(registerRestActionRequest, discoveryExtensionNode, transportService, identityService)
         );
     }
 }


### PR DESCRIPTION
### Description

Introduces IdentityPlugin with initial interface for extensions use-cases. Details about plans for Security for Extensions can be found here: https://gist.github.com/cwperks/e756e1cead72cd511d819241a11337e8

For an example of usage in the Security Plugin please see: https://github.com/cwperks/security/pull/3

For a quick summary, the [extensions project](https://github.com/opensearch-project/OpenSearch/issues/2447) is a major effort in the OpenSearch community to promote contributions to OpenSearch by having extensions discoverable through a catalog. Extensions may or may not run in the same JVM as the ES process, but in either case interfaces are being built to ensure that extensions run in a secure fashion and are restricted with how actions originating from an extension can interact with an OpenSearch cluster. In the current plugin architecture of OpenSearch, plugins are granted a lot of trust, especially with the ability to stash the thread context to assume super user access to a cluster. With extensions, there is a more explicit trust boundary between OpenSearch core and an extension and this PR introduces a new `IdentityPlugin` interface which will provide the bridge between OpenSearch core and an extension.

In an OpenSearch node with the Security plugin installed, the Security plugin wraps a REST request to authenticate the request and enrich the thread context with user info (in the `_opendistro_security_user` threadcontext transient header). If this header is present in the threadcontext, then it means that the current subject exists and is authenticated (not necessarily authorized! That is a check that is performed later with the `getActionFilters()` extension point as the very first filter that is applied - See [SecurityFilter](https://github.com/opensearch-project/security/blob/main/src/main/java/org/opensearch/security/filter/SecurityFilter.java) for authz details).

For extensions, the threadcontext is not shared with an extension and in its place the extension will be issued an access token on-behalf-of the authenticated user. This access token permits the extension to make REST requests back to the OpenSearch cluster utilizing this token. To understand how a request utilizing the **on-behalf-of token** would be authorized please see [On-behalf-of Tokens Authorization](https://gist.github.com/cwperks/e756e1cead72cd511d819241a11337e8#on-behalf-of-tokens-authorization)

This PR introduces an experimental new extension point `IdentityPlugin` that contains interfaces to enable security for extensions use-cases. This extension point is only meant to be implemented once - similar to the tailor-made [ActionPlugin.getRestHandlerWrapper](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/plugins/ActionPlugin.java#L130-L153) which allows the Security plugin to intercept REST requests to the cluster to authenticate a request.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
