### PR TITLE
Add check to ensure REST action name is unique across all registered actions

### DIFF
--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -181,7 +181,7 @@ public class ExtensionsManager {
             actionModule,
             this
         );
-        registerRequestHandler();
+        registerRequestHandler(actionModule);
     }
 
     /**
@@ -222,14 +222,16 @@ public class ExtensionsManager {
         return extensionTransportActionsHandler.sendTransportRequestToExtension(request);
     }
 
-    private void registerRequestHandler() {
+    private void registerRequestHandler(ActionModule actionModule) {
         transportService.registerRequestHandler(
             REQUEST_EXTENSION_REGISTER_REST_ACTIONS,
             ThreadPool.Names.GENERIC,
             false,
             false,
             RegisterRestActionsRequest::new,
-            ((request, channel, task) -> channel.sendResponse(restActionsRequestHandler.handleRegisterRestActionsRequest(request)))
+            ((request, channel, task) -> channel.sendResponse(
+                restActionsRequestHandler.handleRegisterRestActionsRequest(request, actionModule)
+            ))
         );
         transportService.registerRequestHandler(
             REQUEST_EXTENSION_REGISTER_CUSTOM_SETTINGS,

--- a/server/src/main/java/org/opensearch/extensions/rest/RestActionsRequestHandler.java
+++ b/server/src/main/java/org/opensearch/extensions/rest/RestActionsRequestHandler.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.extensions.rest;
 
+import org.opensearch.action.ActionModule;
 import org.opensearch.extensions.AcknowledgedResponse;
 import org.opensearch.extensions.DiscoveryExtensionNode;
 import org.opensearch.rest.RestController;
@@ -53,9 +54,10 @@ public class RestActionsRequestHandler {
      * @return A {@link AcknowledgedResponse} indicating success.
      * @throws Exception if the request is not handled properly.
      */
-    public TransportResponse handleRegisterRestActionsRequest(RegisterRestActionsRequest restActionsRequest) throws Exception {
+    public TransportResponse handleRegisterRestActionsRequest(RegisterRestActionsRequest restActionsRequest, ActionModule actionModule)
+        throws Exception {
         DiscoveryExtensionNode discoveryExtensionNode = extensionIdMap.get(restActionsRequest.getUniqueId());
-        RestHandler handler = new RestSendToExtensionAction(restActionsRequest, discoveryExtensionNode, transportService);
+        RestHandler handler = new RestSendToExtensionAction(restActionsRequest, discoveryExtensionNode, transportService, actionModule);
         restController.registerHandler(handler);
         return new AcknowledgedResponse(true);
     }

--- a/server/src/main/java/org/opensearch/rest/extensions/RestSendToExtensionAction.java
+++ b/server/src/main/java/org/opensearch/rest/extensions/RestSendToExtensionAction.java
@@ -10,6 +10,7 @@ package org.opensearch.rest.extensions;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionModule;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.io.stream.StreamInput;
@@ -83,7 +84,8 @@ public class RestSendToExtensionAction extends BaseRestHandler {
     public RestSendToExtensionAction(
         RegisterRestActionsRequest restActionsRequest,
         DiscoveryExtensionNode discoveryExtensionNode,
-        TransportService transportService
+        TransportService transportService,
+        ActionModule actionModule
     ) {
         this.pathPrefix = "/_extensions/_" + restActionsRequest.getUniqueId();
         RestRequest.Method method;
@@ -107,7 +109,9 @@ public class RestSendToExtensionAction extends BaseRestHandler {
             }
             logger.info("Registering: " + method + " " + path);
             if (name.isPresent()) {
-                restActionsAsRoutes.add(new NamedRoute(method, path, name.get()));
+                NamedRoute nr = new NamedRoute(method, path, name.get());
+                restActionsAsRoutes.add(nr);
+                actionModule.registerNamedRoute(nr);
             } else {
                 restActionsAsRoutes.add(new Route(method, path));
             }

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
@@ -474,7 +474,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
         List<String> deprecatedActionsList = List.of("GET /deprecated/foo", "It's deprecated!");
         RegisterRestActionsRequest registerActionsRequest = new RegisterRestActionsRequest(uniqueIdStr, actionsList, deprecatedActionsList);
         TransportResponse response = extensionsManager.getRestActionsRequestHandler()
-            .handleRegisterRestActionsRequest(registerActionsRequest);
+            .handleRegisterRestActionsRequest(registerActionsRequest, actionModule);
         assertEquals(AcknowledgedResponse.class, response.getClass());
         assertTrue(((AcknowledgedResponse) response).getStatus());
     }
@@ -506,7 +506,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
         RegisterRestActionsRequest registerActionsRequest = new RegisterRestActionsRequest(uniqueIdStr, actionsList, deprecatedActionsList);
         expectThrows(
             IllegalArgumentException.class,
-            () -> extensionsManager.getRestActionsRequestHandler().handleRegisterRestActionsRequest(registerActionsRequest)
+            () -> extensionsManager.getRestActionsRequestHandler().handleRegisterRestActionsRequest(registerActionsRequest, actionModule)
         );
     }
 
@@ -520,7 +520,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
         RegisterRestActionsRequest registerActionsRequest = new RegisterRestActionsRequest(uniqueIdStr, actionsList, deprecatedActionsList);
         expectThrows(
             IllegalArgumentException.class,
-            () -> extensionsManager.getRestActionsRequestHandler().handleRegisterRestActionsRequest(registerActionsRequest)
+            () -> extensionsManager.getRestActionsRequestHandler().handleRegisterRestActionsRequest(registerActionsRequest, actionModule)
         );
     }
 
@@ -533,7 +533,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
         RegisterRestActionsRequest registerActionsRequest = new RegisterRestActionsRequest(uniqueIdStr, actionsList, deprecatedActionsList);
         expectThrows(
             IllegalArgumentException.class,
-            () -> extensionsManager.getRestActionsRequestHandler().handleRegisterRestActionsRequest(registerActionsRequest)
+            () -> extensionsManager.getRestActionsRequestHandler().handleRegisterRestActionsRequest(registerActionsRequest, actionModule)
         );
     }
 
@@ -546,7 +546,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
         RegisterRestActionsRequest registerActionsRequest = new RegisterRestActionsRequest(uniqueIdStr, actionsList, deprecatedActionsList);
         expectThrows(
             IllegalArgumentException.class,
-            () -> extensionsManager.getRestActionsRequestHandler().handleRegisterRestActionsRequest(registerActionsRequest)
+            () -> extensionsManager.getRestActionsRequestHandler().handleRegisterRestActionsRequest(registerActionsRequest, actionModule)
         );
     }
 

--- a/server/src/test/java/org/opensearch/extensions/rest/RestSendToExtensionActionTests.java
+++ b/server/src/test/java/org/opensearch/extensions/rest/RestSendToExtensionActionTests.java
@@ -206,7 +206,7 @@ public class RestSendToExtensionActionTests extends OpenSearchTestCase {
     public void testRestSendToExtensionWithNamedRouteCollidingWithNativeAction() throws Exception {
         RegisterRestActionsRequest registerRestActionRequest = new RegisterRestActionsRequest(
             "uniqueid1",
-            List.of("GET /foo " + ClusterHealthAction.NAME, "PUT /bar foo"),
+            List.of("GET /foo " + ClusterHealthAction.NAME),
             List.of()
         );
         expectThrows(


### PR DESCRIPTION
### Description

This PR builds off of https://github.com/opensearch-project/OpenSearch/pull/6870 to ensure that any registered `NamedRoute` has a name that is unique across all registered native actions, plugin actions and actions registered in the dynamic action registry. If there is a name collision then it will throw an OpenSearchException with message indicating that an action with that action name already exists. 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
