### PR TITLE
Fips build tooling cwperx

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchCluster.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchCluster.java
@@ -470,6 +470,11 @@ public class OpenSearchCluster implements TestClusterConfiguration, Named {
     }
 
     @Override
+    public void removeJarFile(File from, String module) {
+        nodes.all(node -> node.removeJarFile(from, module));
+    }
+
+    @Override
     public void user(Map<String, String> userSpec) {
         nodes.all(node -> node.user(userSpec));
     }

--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
@@ -157,6 +157,7 @@ public class OpenSearchNode implements TestClusterConfiguration {
     private final LazyPropertyList<CharSequence> jvmArgs = new LazyPropertyList<>("JVM arguments", this);
     private final LazyPropertyMap<String, File> extraConfigFiles = new LazyPropertyMap<>("Extra config files", this, FileEntry::new);
     private final LazyPropertyList<File> extraJarFiles = new LazyPropertyList<>("Extra jar files", this);
+    private final LazyPropertyMap<String, File> removeJarFiles = new LazyPropertyMap<>("Jar files to remove", this);
     private final List<Map<String, String>> credentials = new ArrayList<>();
     final LinkedHashMap<String, String> defaultConfig = new LinkedHashMap<>();
 
@@ -661,6 +662,21 @@ public class OpenSearchNode implements TestClusterConfiguration {
                 throw new UncheckedIOException("Can't copy extra jar dependency " + from.getName() + " to " + destination, e);
             }
         });
+        try {
+            Files.deleteIfExists(getDistroDir().resolve("modules/reindex/bcutil-fips-2.0.3.jar"));
+            Files.deleteIfExists(getDistroDir().resolve("modules/reindex/bcpkix-fips-2.0.7.jar"));
+            Files.deleteIfExists(getDistroDir().resolve("modules/reindex/bc-fips-2.0.0.jar"));
+            Files.deleteIfExists(getDistroDir().resolve("modules/reindex/bctls-fips-2.0.19.jar"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        if (removeJarFiles.isEmpty() == false) {
+            // TODO make this message more verbose
+            logToProcessStdout("Removing jar files " + removeJarFiles.size());
+        }
+//        for (String module : removeJarFiles.keySet()) {
+//            Files.deleteIfExists(getDistroDir().resolve("modules/" + module + "/" + from))
+//        }
     }
 
     private void installModules() {
@@ -710,6 +726,14 @@ public class OpenSearchNode implements TestClusterConfiguration {
             throw new IllegalArgumentException("extra jar file " + from.toString() + " doesn't appear to be a JAR");
         }
         extraJarFiles.add(from);
+    }
+
+    @Override
+    public void removeJarFile(File from, String module) {
+        if (from.toString().endsWith(".jar") == false) {
+            throw new IllegalArgumentException("jar file to remove " + from.toString() + " doesn't appear to be a JAR");
+        }
+        // extraJarFiles.add(from);
     }
 
     @Override

--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/TestClusterConfiguration.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/TestClusterConfiguration.java
@@ -122,6 +122,8 @@ public interface TestClusterConfiguration {
 
     void extraJarFile(File from);
 
+    void removeJarFile(File from, String module);
+
     void user(Map<String, String> userSpec);
 
     String getHttpSocketURI();

--- a/qa/fips-compliance/build.gradle
+++ b/qa/fips-compliance/build.gradle
@@ -33,14 +33,6 @@ testClusters.integTest {
   // TODO Remove BCFIPS jars from modules/reindex
   configurations.bouncycastleFips.files.each { jarFile ->
     extraJarFile jarFile
-  }
-//  delete fileTree("${project.buildDir}/lib") {
-//    include 'bc-fips-*.jar', 'bcpkix-fips-*.jar'
-//  }
-  nodes.each { node ->
-    String homeDir = node.distroDir.toString()
-
-    // Example usage:
-    println "Test cluster home directory: " + homeDir
+    removeJarFile(jarFile, "reindex")
   }
 }

--- a/qa/fips-compliance/build.gradle
+++ b/qa/fips-compliance/build.gradle
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+apply plugin: 'opensearch.testclusters'
+apply plugin: 'opensearch.standalone-rest-test'
+apply plugin: 'opensearch.rest-test'
+apply plugin: 'opensearch.rest-resources'
+
+configurations {
+  bouncycastleFips
+}
+
+dependencies {
+  bouncycastleFips 'org.bouncycastle:bc-fips:2.0.0'
+  bouncycastleFips 'org.bouncycastle:bcutil-fips:2.0.3'
+  bouncycastleFips 'org.bouncycastle:bcpkix-fips:2.0.7'
+  bouncycastleFips 'org.bouncycastle:bctls-fips:2.0.19'
+}
+
+testClusters.integTest {
+  systemProperty 'org.bouncycastle.fips.approved_only', 'true'
+  // systemProperty 'crypto.standard', 'FIPS-140-3'
+  keystorePassword 'notarealpasswordphrase'
+
+  // TODO Remove BCFIPS jars from modules/reindex
+  configurations.bouncycastleFips.files.each { jarFile ->
+    extraJarFile jarFile
+  }
+//  delete fileTree("${project.buildDir}/lib") {
+//    include 'bc-fips-*.jar', 'bcpkix-fips-*.jar'
+//  }
+  nodes.each { node ->
+    String homeDir = node.distroDir.toString()
+
+    // Example usage:
+    println "Test cluster home directory: " + homeDir
+  }
+}

--- a/qa/fips-compliance/src/test/java/org/opensearch/smoketest/SmokeTestPluginsClientYamlTestSuiteIT.java
+++ b/qa/fips-compliance/src/test/java/org/opensearch/smoketest/SmokeTestPluginsClientYamlTestSuiteIT.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.smoketest;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.opensearch.test.rest.yaml.ClientYamlTestCandidate;
+import org.opensearch.test.rest.yaml.OpenSearchClientYamlSuiteTestCase;
+
+public class SmokeTestPluginsClientYamlTestSuiteIT extends OpenSearchClientYamlSuiteTestCase {
+
+    public SmokeTestPluginsClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
+        super(testCandidate);
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() throws Exception {
+        return OpenSearchClientYamlSuiteTestCase.createParameters();
+    }
+}

--- a/qa/fips-compliance/src/test/resources/rest-api-spec/test/smoke_test_plugins/10_basic.yml
+++ b/qa/fips-compliance/src/test/resources/rest-api-spec/test/smoke_test_plugins/10_basic.yml
@@ -1,0 +1,13 @@
+# Integration tests for smoke testing plugins
+#
+"Correct Plugin Count":
+    - do:
+        cluster.state: {}
+
+    # Get cluster-manager node id
+    - set: { cluster_manager_node: cluster_manager }
+
+    - do:
+        nodes.info: {}
+
+    - length:  { nodes.$cluster_manager.plugins: 0  }

--- a/server/src/main/java/org/opensearch/common/Randomness.java
+++ b/server/src/main/java/org/opensearch/common/Randomness.java
@@ -143,6 +143,8 @@ public final class Randomness {
             Method isApprovedOnlyMethod = registrarClass.getMethod("isInApprovedOnlyMode");
             boolean approvedOnly = (Boolean) isApprovedOnlyMethod.invoke(null);
 
+            System.out.println("approvedOnly: " + approvedOnly);
+
             if (approvedOnly) {
                 Class<?> basicEntropyProviderClass = Class.forName("org.bouncycastle.crypto.util.BasicEntropySourceProvider");
                 Constructor<?> entropyConstructor = basicEntropyProviderClass.getConstructor(SecureRandom.class, boolean.class);
@@ -166,6 +168,7 @@ public final class Randomness {
 
             return SecureRandom.getInstanceStrong();
         } catch (ReflectiveOperationException | GeneralSecurityException e) {
+            System.out.println("Using default SecureRandom");
             try {
                 return SecureRandom.getInstanceStrong();
             } catch (NoSuchAlgorithmException ex) {


### PR DESCRIPTION
### Description

This PR adds a new qa test module to run a testcluster in FIPS-140-3 approved mode.

One of the complications encountered in writing a test is that there is a jarHell issue when the BCFIPS dependencies are provided in the `lib/` folder. The jarHell is between the reindex module and `lib/` since the reindex module's classLoader also includes all jars in the `lib/` directory.

To solve the jarHell issue, its necessary to remove the BCFIPS libs from the reindex module when running in FIPS approved mode. They will still be on the runtime classpath for the reindex module if the jars are included in the `lib/` folder.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
