### PR TITLE
Ensure that transient ThreadContext headers with propagators survive stash and restore

### DIFF
--- a/server/src/main/java/org/opensearch/common/util/concurrent/ThreadContext.java
+++ b/server/src/main/java/org/opensearch/common/util/concurrent/ThreadContext.java
@@ -175,7 +175,34 @@ public final class ThreadContext implements Writeable {
             // If the node and thus the threadLocal get closed while this task
             // is still executing, we don't want this runnable to fail with an
             // uncaught exception
-            threadLocal.set(context);
+            //
+            // Re-apply propagator-declared transients from the stashed context back into the
+            // snapshot being restored. This ensures that transients written during the stash
+            // window (e.g. CURRENT_SPAN set by the tracing infrastructure) are not silently
+            // dropped when the security plugin (or any other caller) calls storedContext.restore().
+            // Without this, restore() would blindly overwrite the threadLocal with the original
+            // snapshot, losing any propagated transients that were set after the stash point.
+            final ThreadContextStruct current = threadLocal.get();
+            final Map<String, Object> propagated = propagateTransients(current.transientHeaders, current.isSystemContext);
+            if (propagated.isEmpty()) {
+                threadLocal.set(context);
+            } else {
+                // Merge: start from the snapshot, then overlay propagated transients.
+                // We use putIfAbsent semantics so that values already in the snapshot
+                // (set before the stash) are not overwritten.
+                final Map<String, Object> merged = new HashMap<>(context.transientHeaders);
+                propagated.forEach(merged::putIfAbsent);
+                threadLocal.set(
+                    new ThreadContextStruct(
+                        context.requestHeaders,
+                        context.responseHeaders,
+                        merged,
+                        context.persistentHeaders,
+                        context.isSystemContext,
+                        context.warningHeadersSize
+                    )
+                );
+            }
         };
     }
 

--- a/server/src/test/java/org/opensearch/common/util/concurrent/ThreadContextTests.java
+++ b/server/src/test/java/org/opensearch/common/util/concurrent/ThreadContextTests.java
@@ -784,6 +784,51 @@ public class ThreadContextTests extends OpenSearchTestCase {
         assertEquals("1", threadContext.getHeader("default"));
     }
 
+    public void testPropagatedTransientsSurviveRestore() {
+        // Reproduces the scenario from opensearch-project/security#6000:
+        // the security plugin calls storedContext.restore() after writing security headers,
+        // which previously wiped any propagator-declared transients (e.g. CURRENT_SPAN)
+        // that were set after the stash point.
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+
+        final String PROPAGATED_KEY = "test_propagated_transient";
+        final Object PROPAGATED_VALUE = new Object();
+
+        // Register a propagator that declares PROPAGATED_KEY as a transient to carry across stashes.
+        threadContext.registerThreadContextStatePropagator(new ThreadContextStatePropagator() {
+            @Override
+            @SuppressWarnings("removal")
+            public Map<String, Object> transients(Map<String, Object> source) {
+                if (source.containsKey(PROPAGATED_KEY)) {
+                    return Collections.singletonMap(PROPAGATED_KEY, source.get(PROPAGATED_KEY));
+                }
+                return Collections.emptyMap();
+            }
+
+            @Override
+            @SuppressWarnings("removal")
+            public Map<String, String> headers(Map<String, Object> source) {
+                return Collections.emptyMap();
+            }
+        });
+
+        ThreadContext.StoredContext storedContext = threadContext.stashContext();
+
+        // Simulate the tracing infrastructure writing CURRENT_SPAN into the stashed context.
+        threadContext.putTransient(PROPAGATED_KEY, PROPAGATED_VALUE);
+        assertSame(PROPAGATED_VALUE, threadContext.getTransient(PROPAGATED_KEY));
+
+        // Simulate the security plugin calling restore() after populating security headers.
+        storedContext.restore();
+
+        // The propagated transient must still be visible after restore.
+        assertSame(
+            "propagator-declared transient must survive storedContext.restore()",
+            PROPAGATED_VALUE,
+            threadContext.getTransient(PROPAGATED_KEY)
+        );
+    }
+
     public void testSerializeSystemContext() throws IOException {
         Settings build = Settings.builder().put("request.headers.default", "1").build();
         Map<String, Object> transientHeaderMap = Collections.singletonMap("test_transient_propagation_key", "test");

--- a/server/src/test/java/org/opensearch/common/util/concurrent/ThreadContextTests.java
+++ b/server/src/test/java/org/opensearch/common/util/concurrent/ThreadContextTests.java
@@ -812,10 +812,11 @@ public class ThreadContextTests extends OpenSearchTestCase {
             }
         });
 
-        ThreadContext.StoredContext storedContext = threadContext.stashContext();
-
         // Simulate the tracing infrastructure writing CURRENT_SPAN into the stashed context.
         threadContext.putTransient(PROPAGATED_KEY, PROPAGATED_VALUE);
+
+        ThreadContext.StoredContext storedContext = threadContext.stashContext();
+
         assertSame(PROPAGATED_VALUE, threadContext.getTransient(PROPAGATED_KEY));
 
         // Simulate the security plugin calling restore() after populating security headers.


### PR DESCRIPTION
### Description

Ensure that transient ThreadContext headers with propagators survive stash and restore

### Related Issues

Related to https://github.com/opensearch-project/security/issues/5990

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
