### PR TITLE
Add marker to BaseRestHandler for privileged apis

### DIFF
--- a/server/src/main/java/org/opensearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/BaseRestHandler.java
@@ -334,6 +334,11 @@ public abstract class BaseRestHandler implements RestHandler {
         }
 
         @Override
+        public boolean requiresSecurityAdminAccess() {
+            return delegate.requiresSecurityAdminAccess();
+        }
+
+        @Override
         public boolean supportsStreaming() {
             return delegate.supportsStreaming();
         }

--- a/server/src/main/java/org/opensearch/rest/DeprecationRestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/DeprecationRestHandler.java
@@ -82,6 +82,11 @@ public class DeprecationRestHandler implements RestHandler {
         return handler.supportsContentStream();
     }
 
+    @Override
+    public boolean requiresSecurityAdminAccess() {
+        return handler.requiresSecurityAdminAccess();
+    }
+
     /**
      * This does a very basic pass at validating that a header's value contains only expected characters according to RFC-5987, and those
      * that it references.

--- a/server/src/main/java/org/opensearch/rest/RestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/RestHandler.java
@@ -126,6 +126,17 @@ public interface RestHandler {
     }
 
     /**
+     * Controls whether requests handled by this class require security-admin style authorization.
+     * Plugins can opt into this marker so a security implementation can apply privileged authorization
+     * before dispatching the request to the handler.
+     *
+     * @return {@code true} if requests handled by this class require security-admin style authorization.
+     */
+    default boolean requiresSecurityAdminAccess() {
+        return false;
+    }
+
+    /**
      * Denotes whether the RestHandler will output paginated responses or not.
      */
     default boolean isActionPaginated() {
@@ -191,6 +202,11 @@ public interface RestHandler {
         @Override
         public boolean allowSystemIndexAccessByDefault() {
             return delegate.allowSystemIndexAccessByDefault();
+        }
+
+        @Override
+        public boolean requiresSecurityAdminAccess() {
+            return delegate.requiresSecurityAdminAccess();
         }
 
         @Override

--- a/server/src/test/java/org/opensearch/rest/DeprecationRestHandlerTests.java
+++ b/server/src/test/java/org/opensearch/rest/DeprecationRestHandlerTests.java
@@ -152,6 +152,16 @@ public class DeprecationRestHandlerTests extends OpenSearchTestCase {
         assertFalse(new DeprecationRestHandler(handler, deprecationMessage, deprecationLogger).supportsContentStream());
     }
 
+    public void testRequiresSecurityAdminAccessTrue() {
+        when(handler.requiresSecurityAdminAccess()).thenReturn(true);
+        assertTrue(new DeprecationRestHandler(handler, deprecationMessage, deprecationLogger).requiresSecurityAdminAccess());
+    }
+
+    public void testRequiresSecurityAdminAccessFalse() {
+        when(handler.requiresSecurityAdminAccess()).thenReturn(false);
+        assertFalse(new DeprecationRestHandler(handler, deprecationMessage, deprecationLogger).requiresSecurityAdminAccess());
+    }
+
     /**
      * {@code ASCIIHeaderGenerator} only uses characters expected to be valid in headers (simplified US-ASCII).
      */


### PR DESCRIPTION
### Description

Adds a new method to BaseRestHandler to mark RestHandlers as privileged to differentiate how these APIs are authorized separately than the usual authz by transport action name.

The security repo already authorizes its APIs separate from other OpenSearch APIs and this marker allows RestHandlers outside of the security repo to authorize similar to Security APIs.

Needed to support APIs in the job scheduler plugin which should be restricted to security admin.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
