### PR TITLE
Add core standby mode setting

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -211,6 +211,14 @@ import static org.opensearch.gateway.remote.RemoteManifestManager.METADATA_MANIF
 @PublicApi(since = "1.0.0")
 public final class ClusterSettings extends AbstractScopedSettings {
 
+    public static final Setting<Boolean> CLUSTER_STANDBY_MODE_SETTING = Setting.boolSetting(
+        "cluster.standby_mode",
+        false,
+        Property.NodeScope,
+        Property.Dynamic,
+        Property.Sensitive
+    );
+
     public ClusterSettings(final Settings nodeSettings, final Set<Setting<?>> settingsSet) {
         this(nodeSettings, settingsSet, Collections.emptySet());
     }
@@ -660,6 +668,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 OperationRouting.STRICT_WEIGHTED_SHARD_ROUTING_ENABLED,
                 OperationRouting.IGNORE_WEIGHTED_SHARD_ROUTING,
                 OperationRouting.STRICT_SEARCH_REPLICA_ROUTING_ENABLED,
+                CLUSTER_STANDBY_MODE_SETTING,
                 IndexGraveyard.SETTING_MAX_TOMBSTONES,
                 PersistentTasksClusterService.CLUSTER_TASKS_ALLOCATION_RECHECK_INTERVAL_SETTING,
                 EnableAssignmentDecider.CLUSTER_TASKS_ALLOCATION_ENABLE_SETTING,

--- a/server/src/test/java/org/opensearch/common/settings/ScopedSettingsTests.java
+++ b/server/src/test/java/org/opensearch/common/settings/ScopedSettingsTests.java
@@ -763,6 +763,8 @@ public class ScopedSettingsTests extends OpenSearchTestCase {
         assertTrue(settings.isDynamicSetting("transport.tracer.include." + randomIntBetween(1, 100)));
         assertFalse(settings.isDynamicSetting("transport.tracer.include.BOOM"));
         assertTrue(settings.isDynamicSetting("cluster.routing.allocation.require.value"));
+        assertTrue(settings.isDynamicSetting(ClusterSettings.CLUSTER_STANDBY_MODE_SETTING.getKey()));
+        assertTrue(settings.isSensitiveSetting(ClusterSettings.CLUSTER_STANDBY_MODE_SETTING.getKey()));
     }
 
     public void testIsFinal() {


### PR DESCRIPTION
### Description

Adds a built-in `cluster.standby_mode` cluster setting.

### Changes

- Adds `ClusterSettings.CLUSTER_STANDBY_MODE_SETTING`.
  - key: `cluster.standby_mode`
  - default: `false`
  - properties: `NodeScope`, `Dynamic`, `Sensitive`
- Registers the setting in `ClusterSettings.BUILT_IN_CLUSTER_SETTINGS`.
- Adds test coverage verifying the setting is dynamic and sensitive.

### Notes

This PR only adds the shared setting. It does not add standby-mode behavior to core services or plugins.

### Testing

```bash
./gradlew :server:test --tests org.opensearch.common.settings.ScopedSettingsTests --tests org.opensearch.action.admin.cluster.settings.SettingsUpdaterTests
git diff --check
```