### PR TITLE
Add Property.Intrinsic for index settings

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -696,7 +696,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         -1,
         -1,
         Property.IndexScope,
-        Property.Final
+        Property.Final,
+        Property.Intrinsic
     );
 
     /**
@@ -730,7 +731,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         INDEX_UUID_NA_VALUE,
         Property.IndexScope,
         Property.PrivateIndex,
-        Property.UnmodifiableOnRestore
+        Property.UnmodifiableOnRestore,
+        Property.Intrinsic
     );
 
     public static final Setting<String> SETTING_INDEX_HISTORY_UUID = Setting.simpleString(
@@ -738,7 +740,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         INDEX_UUID_NA_VALUE,
         Property.IndexScope,
         Property.PrivateIndex,
-        Property.UnmodifiableOnRestore
+        Property.UnmodifiableOnRestore,
+        Property.Intrinsic
     );
 
     public static final String INDEX_ROUTING_REQUIRE_GROUP_PREFIX = "index.routing.allocation.require";

--- a/server/src/main/java/org/opensearch/common/settings/Setting.java
+++ b/server/src/main/java/org/opensearch/common/settings/Setting.java
@@ -185,7 +185,14 @@ public class Setting<T> implements ToXContentObject {
          * different policies for these settings. In practice the security plugin will
          * require higher privileges for modifying sensitive settings.
          */
-        Sensitive
+        Sensitive,
+
+        /**
+         * Marks a setting as intrinsic to the cluster. Its value is determined by cluster
+         * identity or topology and is not meaningful to compare across clusters.
+         * Cross-cluster replication uses this to exclude settings from metadata comparison.
+         */
+        Intrinsic
     }
 
     private final Key key;
@@ -401,6 +408,14 @@ public class Setting<T> implements ToXContentObject {
      */
     public boolean isFiltered() {
         return properties.contains(Property.Filtered);
+    }
+
+    /**
+     * Returns <code>true</code> if this setting is intrinsic to the cluster and should not be
+     * compared across clusters in cross-cluster replication scenarios.
+     */
+    public boolean isIntrinsic() {
+        return properties.contains(Property.Intrinsic);
     }
 
     /**

--- a/server/src/test/java/org/opensearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/opensearch/common/settings/SettingTests.java
@@ -1821,4 +1821,20 @@ public class SettingTests extends OpenSearchTestCase {
             mockLogAppender.assertAllExpectationsMatched();
         }
     }
+
+    public void testIntrinsicProperty() {
+        Setting<String> intrinsicSetting = Setting.simpleString("foo.bar", Property.IndexScope, Property.Intrinsic);
+        assertTrue(intrinsicSetting.isIntrinsic());
+
+        Setting<String> normalSetting = Setting.simpleString("foo.baz", Property.IndexScope);
+        assertFalse(normalSetting.isIntrinsic());
+    }
+
+    public void testIndexUuidIsIntrinsic() {
+        assertTrue(IndexMetadata.INDEX_UUID_SETTING.isIntrinsic());
+    }
+
+    public void testIndexCreationDateIsIntrinsic() {
+        assertTrue(IndexMetadata.SETTING_INDEX_CREATION_DATE.isIntrinsic());
+    }
 }


### PR DESCRIPTION
# Add `Property.Intrinsic` to `Setting`

## Summary

Adds a new `Setting.Property.Intrinsic` flag that marks settings whose values are determined by cluster identity or topology and are not meaningful to compare across clusters.

## Motivation

When comparing metadata between two connected clusters (e.g., for replication validation), certain index settings always differ by design — `index.uuid` is generated at creation time, `index.creation_date` reflects when the index was created on that specific cluster. Comparing these is meaningless and produces noise.

Today, consumers that need to skip these settings maintain hardcoded strip-lists. This flag makes the intent declarative and co-located with the setting definition, so:
- Developers see the replication semantics when reading the setting
- New settings prompt the question \"is this intrinsic?\" during review
- Consumers can query `setting.isIntrinsic()` instead of maintaining external lists

## Changes

**`Setting.java`**
- Added `Intrinsic` to the `Property` enum
- Added `isIntrinsic()` convenience method

**`IndexMetadata.java`**
- Tagged `INDEX_UUID_SETTING` with `Property.Intrinsic`
- Tagged `SETTING_INDEX_CREATION_DATE` with `Property.Intrinsic`
- Tagged `SETTING_INDEX_HISTORY_UUID` with `Property.Intrinsic`

## Follow-up work

- Tag index routing allocation affix settings (`index.routing.allocation.require.*`, `include.*`, `exclude.*`)
- Tag cluster-level topology/sizing settings in subsequent PRs
- Update the CCR diff API to use `isIntrinsic()` instead of a hardcoded strip list"