### PR TITLE
Tag cluster-level topology/sizing settings as Property.Intrinsic

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/ClusterName.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterName.java
@@ -59,7 +59,7 @@ public class ClusterName implements Writeable {
             throw new IllegalArgumentException("[cluster.name] must not contain ':'");
         }
         return new ClusterName(s);
-    }, Setting.Property.NodeScope);
+    }, Setting.Property.NodeScope, Setting.Property.Intrinsic);
 
     public static final ClusterName DEFAULT = CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY);
 

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettings.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettings.java
@@ -58,13 +58,15 @@ public class DiskThresholdSettings {
         "cluster.routing.allocation.disk.threshold_enabled",
         true,
         Setting.Property.Dynamic,
-        Setting.Property.NodeScope
+        Setting.Property.NodeScope,
+        Setting.Property.Intrinsic
     );
     public static final Setting<Boolean> CLUSTER_ROUTING_ALLOCATION_WARM_DISK_THRESHOLD_ENABLED_SETTING = Setting.boolSetting(
         "cluster.routing.allocation.disk.warm_threshold_enabled",
         true,
         Setting.Property.Dynamic,
-        Setting.Property.NodeScope
+        Setting.Property.NodeScope,
+        Setting.Property.Intrinsic
     );
     public static final Setting<Boolean> ENABLE_FOR_SINGLE_DATA_NODE = Setting.boolSetting(
         "cluster.routing.allocation.disk.watermark.enable_for_single_data_node",
@@ -77,7 +79,8 @@ public class DiskThresholdSettings {
         (s) -> validWatermarkSetting(s, "cluster.routing.allocation.disk.watermark.low"),
         new LowDiskWatermarkValidator(),
         Setting.Property.Dynamic,
-        Setting.Property.NodeScope
+        Setting.Property.NodeScope,
+        Setting.Property.Intrinsic
     );
     public static final Setting<String> CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING = new Setting<>(
         "cluster.routing.allocation.disk.watermark.high",
@@ -85,7 +88,8 @@ public class DiskThresholdSettings {
         (s) -> validWatermarkSetting(s, "cluster.routing.allocation.disk.watermark.high"),
         new HighDiskWatermarkValidator(),
         Setting.Property.Dynamic,
-        Setting.Property.NodeScope
+        Setting.Property.NodeScope,
+        Setting.Property.Intrinsic
     );
     public static final Setting<String> CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING = new Setting<>(
         "cluster.routing.allocation.disk.watermark.flood_stage",
@@ -93,7 +97,8 @@ public class DiskThresholdSettings {
         (s) -> validWatermarkSetting(s, "cluster.routing.allocation.disk.watermark.flood_stage"),
         new FloodStageValidator(),
         Setting.Property.Dynamic,
-        Setting.Property.NodeScope
+        Setting.Property.NodeScope,
+        Setting.Property.Intrinsic
     );
     public static final Setting<Boolean> CLUSTER_ROUTING_ALLOCATION_INCLUDE_RELOCATIONS_SETTING = Setting.boolSetting(
         "cluster.routing.allocation.disk.include_relocations",

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
@@ -90,15 +90,15 @@ public class FilterAllocationDecider extends AllocationDecider {
     private static final String CLUSTER_ROUTING_EXCLUDE_GROUP_PREFIX = "cluster.routing.allocation.exclude";
     public static final Setting.AffixSetting<String> CLUSTER_ROUTING_REQUIRE_GROUP_SETTING = Setting.prefixKeySetting(
         CLUSTER_ROUTING_REQUIRE_GROUP_PREFIX + ".",
-        key -> Setting.simpleString(key, value -> IP_VALIDATOR.accept(key, value), Property.Dynamic, Property.NodeScope)
+        key -> Setting.simpleString(key, value -> IP_VALIDATOR.accept(key, value), Property.Dynamic, Property.NodeScope, Property.Intrinsic)
     );
     public static final Setting.AffixSetting<String> CLUSTER_ROUTING_INCLUDE_GROUP_SETTING = Setting.prefixKeySetting(
         CLUSTER_ROUTING_INCLUDE_GROUP_PREFIX + ".",
-        key -> Setting.simpleString(key, value -> IP_VALIDATOR.accept(key, value), Property.Dynamic, Property.NodeScope)
+        key -> Setting.simpleString(key, value -> IP_VALIDATOR.accept(key, value), Property.Dynamic, Property.NodeScope, Property.Intrinsic)
     );
     public static final Setting.AffixSetting<String> CLUSTER_ROUTING_EXCLUDE_GROUP_SETTING = Setting.prefixKeySetting(
         CLUSTER_ROUTING_EXCLUDE_GROUP_PREFIX + ".",
-        key -> Setting.simpleString(key, value -> IP_VALIDATOR.accept(key, value), Property.Dynamic, Property.NodeScope)
+        key -> Setting.simpleString(key, value -> IP_VALIDATOR.accept(key, value), Property.Dynamic, Property.NodeScope, Property.Intrinsic)
     );
 
     private volatile DiscoveryNodeFilters clusterRequireFilters;

--- a/server/src/main/java/org/opensearch/indices/ShardLimitValidator.java
+++ b/server/src/main/java/org/opensearch/indices/ShardLimitValidator.java
@@ -76,7 +76,8 @@ public class ShardLimitValidator {
         1,
         new MaxShardPerNodeLimitValidator(),
         Setting.Property.Dynamic,
-        Setting.Property.NodeScope
+        Setting.Property.NodeScope,
+        Setting.Property.Intrinsic
     );
 
     public static final Setting<Integer> SETTING_CLUSTER_MAX_SHARDS_PER_CLUSTER = Setting.intSetting(
@@ -85,7 +86,8 @@ public class ShardLimitValidator {
         -1,
         new MaxShardPerClusterLimitValidator(),
         Setting.Property.Dynamic,
-        Setting.Property.NodeScope
+        Setting.Property.NodeScope,
+        Setting.Property.Intrinsic
     );
 
     public static final Setting<Integer> SETTING_CLUSTER_MAX_REMOTE_CAPABLE_SHARDS_PER_NODE = Setting.intSetting(
@@ -94,7 +96,8 @@ public class ShardLimitValidator {
         1,
         new MaxRemoteCapableShardPerNodeLimitValidator(),
         Setting.Property.Dynamic,
-        Setting.Property.NodeScope
+        Setting.Property.NodeScope,
+        Setting.Property.Intrinsic
     );
 
     public static final Setting<Integer> SETTING_CLUSTER_MAX_REMOTE_CAPABLE_SHARDS_PER_CLUSTER = Setting.intSetting(
@@ -103,7 +106,8 @@ public class ShardLimitValidator {
         -1,
         new MaxRemoteCapableShardPerClusterLimitValidator(),
         Setting.Property.Dynamic,
-        Setting.Property.NodeScope
+        Setting.Property.NodeScope,
+        Setting.Property.Intrinsic
     );
 
     public static final Setting<Boolean> SETTING_CLUSTER_IGNORE_DOT_INDEXES = Setting.boolSetting(

--- a/server/src/main/java/org/opensearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/server/src/main/java/org/opensearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -89,7 +89,8 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
     public static final Setting<Boolean> USE_REAL_MEMORY_USAGE_SETTING = Setting.boolSetting(
         "indices.breaker.total.use_real_memory",
         true,
-        Property.NodeScope
+        Property.NodeScope,
+        Property.Intrinsic
     );
 
     public static final Setting<ByteSizeValue> TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING = Setting.memorySizeSetting(


### PR DESCRIPTION
# Tag cluster-level settings as `Property.Intrinsic`

Builds on #359 which introduced `Property.Intrinsic` for index settings.

## Settings tagged

| Setting | File | Why intrinsic |
|---|---|---|
| `cluster.name` | `ClusterName.java` | Cluster identity |
| `cluster.max_shards_per_node` | `ShardLimitValidator.java` | Sizing/capacity |
| `cluster.max_shards_per_cluster` | `ShardLimitValidator.java` | Sizing/capacity |
| `cluster.max_remote_capable_shards_per_node` | `ShardLimitValidator.java` | Sizing/capacity |
| `cluster.routing.allocation.total_remote_capable_shards_limit` | `ShardLimitValidator.java` | Sizing/capacity |
| `cluster.routing.allocation.disk.threshold_enabled` | `DiskThresholdSettings.java` | Node disk capacity |
| `cluster.routing.allocation.disk.warm_threshold_enabled` | `DiskThresholdSettings.java` | Node disk capacity |
| `cluster.routing.allocation.disk.watermark.low` | `DiskThresholdSettings.java` | Node disk capacity |
| `cluster.routing.allocation.disk.watermark.high` | `DiskThresholdSettings.java` | Node disk capacity |
| `cluster.routing.allocation.disk.watermark.flood_stage` | `DiskThresholdSettings.java` | Node disk capacity |
| `cluster.routing.allocation.require.*` | `FilterAllocationDecider.java` | Node attributes (topology) |
| `cluster.routing.allocation.include.*` | `FilterAllocationDecider.java` | Node attributes (topology) |
| `cluster.routing.allocation.exclude.*` | `FilterAllocationDecider.java` | Node attributes (topology) |
| `indices.breaker.total.use_real_memory` | `HierarchyCircuitBreakerService.java` | Node memory capacity |

## Not yet tagged (follow-up)

- `discovery.*` settings
- `gateway.*` settings
- `thread_pool.*` settings
- `remote_store.*` settings
- Remaining `indices.breaker.*` limit/overhead settings"