### PR TITLE
Handle delegation tracker failures in FFM callbacks

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/indexfilter/FilterTreeCallbacks.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/indexfilter/FilterTreeCallbacks.java
@@ -57,14 +57,23 @@ public final class FilterTreeCallbacks {
     }
 
     private static long trackStart() {
-        DelegationThreadTracker t = TRACKER.get();
-        return (t != null) ? t.trackStart() : -1;
+        try {
+            DelegationThreadTracker t = TRACKER.get();
+            return (t != null) ? t.trackStart() : -1;
+        } catch (Throwable throwable) {
+            LOGGER.error("delegation trackStart failed", throwable);
+            return -1;
+        }
     }
 
     private static void trackEnd(long threadId) {
         if (threadId < 0) return;
-        DelegationThreadTracker t = TRACKER.get();
-        if (t != null) t.trackEnd(threadId);
+        try {
+            DelegationThreadTracker t = TRACKER.get();
+            if (t != null) t.trackEnd(threadId);
+        } catch (Throwable throwable) {
+            LOGGER.error(new ParameterizedMessage("delegation trackEnd({}) failed", threadId), throwable);
+        }
     }
 
     // ── Provider lifecycle (cold path, once per query) ────────────────

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/indexfilter/IndexFilterCallbackTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/indexfilter/IndexFilterCallbackTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.be.datafusion.indexfilter;
 
+import org.opensearch.analytics.spi.DelegationThreadTracker;
 import org.opensearch.analytics.spi.FilterDelegationHandle;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -26,11 +27,13 @@ public class IndexFilterCallbackTests extends OpenSearchTestCase {
     public void setUp() throws Exception {
         super.setUp();
         FilterTreeCallbacks.setHandle(null);
+        FilterTreeCallbacks.setThreadTracker(null);
     }
 
     @Override
     public void tearDown() throws Exception {
         FilterTreeCallbacks.setHandle(null);
+        FilterTreeCallbacks.setThreadTracker(null);
         super.tearDown();
     }
 
@@ -120,6 +123,48 @@ public class IndexFilterCallbackTests extends OpenSearchTestCase {
             MemorySegment buf = arena.allocate(Long.BYTES);
             assertEquals(-1L, FilterTreeCallbacks.collectDocs(1, 0, 64, buf, 1));
         }
+    }
+
+    public void testTrackStartFailureDoesNotEscapeCallback() {
+        MockHandle handle = new MockHandle(new long[] { 0x5L });
+        FilterTreeCallbacks.setHandle(handle);
+        FilterTreeCallbacks.setThreadTracker(new DelegationThreadTracker() {
+            @Override
+            public long trackStart() {
+                throw new AssertionError("tracking start failed");
+            }
+
+            @Override
+            public void trackEnd(long threadId) {
+                throw new AssertionError("trackEnd should not be called");
+            }
+        });
+
+        int providerKey = FilterTreeCallbacks.createProvider(42);
+
+        assertTrue("providerKey >= 0", providerKey >= 0);
+        assertEquals("handle received annotationId", 42, handle.lastAnnotationId);
+    }
+
+    public void testTrackEndFailureDoesNotEscapeCallback() {
+        MockHandle handle = new MockHandle(new long[] { 0x5L });
+        FilterTreeCallbacks.setHandle(handle);
+        FilterTreeCallbacks.setThreadTracker(new DelegationThreadTracker() {
+            @Override
+            public long trackStart() {
+                return Thread.currentThread().threadId();
+            }
+
+            @Override
+            public void trackEnd(long threadId) {
+                throw new AssertionError("tracking end failed");
+            }
+        });
+
+        int providerKey = FilterTreeCallbacks.createProvider(42);
+
+        assertTrue("providerKey >= 0", providerKey >= 0);
+        assertEquals("handle received annotationId", 42, handle.lastAnnotationId);
     }
 
     /** Mock handle that records arguments and returns canned bitset words. */

--- a/server/src/test/java/org/opensearch/cluster/DiskUsageTests.java
+++ b/server/src/test/java/org/opensearch/cluster/DiskUsageTests.java
@@ -500,6 +500,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
             null,
             null,
             null,
+            null,
             null
         );
     }


### PR DESCRIPTION
## Summary
- Prevent delegation thread tracking failures from escaping DataFusion FFM callbacks.
- Log tracker failures and continue returning the existing callback result/error value.
- Add callback tests covering trackStart and trackEnd failures.

## Root cause
The sandbox-check failure was triggered by an AssertionError from TaskResourceTrackingService.taskExecutionStartedOnThread during a DataFusion filter-delegation FFM upcall. Because trackStart ran before the callback try/catch block, the AssertionError escaped into Java 25's FFM runtime. The JDK then called SharedUtils.handleUncaughtException, which attempts System.exit(1); OpenSearch's sandbox agent blocked that call and the VM reported the fatal upcallLinker.cpp error.

## Testing
- JAVA_HOME=/Users/craigperkins/.sdkman/candidates/java/25.0.2-amzn ./gradlew -Dsandbox.enabled=true :sandbox:plugins:analytics-backend-datafusion:test --tests org.opensearch.be.datafusion.indexfilter.IndexFilterCallbackTests
- JAVA_HOME=/Users/craigperkins/.sdkman/candidates/java/25.0.2-amzn ./gradlew -Dsandbox.enabled=true :sandbox:plugins:analytics-backend-datafusion:spotlessJavaCheck