### PR TITLE
Rename sandbox PPL execute action

### DIFF
--- a/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/UnifiedPPLExecuteAction.java
+++ b/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/UnifiedPPLExecuteAction.java
@@ -15,7 +15,7 @@ import org.opensearch.action.ActionType;
  * Registered as a transport action in TestPPLPlugin.
  */
 public class UnifiedPPLExecuteAction extends ActionType<PPLResponse> {
-    public static final String NAME = "cluster:internal/qe/unified_ppl_execute";
+    public static final String NAME = "cluster:admin/opensearch/analytics/ppl/execute";
     public static final UnifiedPPLExecuteAction INSTANCE = new UnifiedPPLExecuteAction();
 
     private UnifiedPPLExecuteAction() {


### PR DESCRIPTION
## Summary

Renames the sandbox test PPL frontend execute action from an internal-looking cluster action to a public cluster-scoped action name.

Old action:
`cluster:internal/qe/unified_ppl_execute`

New action:
`cluster:admin/opensearch/analytics/ppl/execute`

## Why

This action backs the REST-facing sandbox PPL endpoint. It is not an internal transport-only action from the perspective of security authorization because a user can reach it through `POST /_analytics/ppl`.

Using `cluster:internal/...` makes the permission look like something users and administrators should not configure directly. That is misleading for security integrations, where a role needs a cluster-level permission to invoke the endpoint before the query engine performs index-level authorization for the indices referenced by the PPL query.

The `cluster:admin/...` namespace is not a perfect semantic fit because this is query execution, not cluster administration. However, it is consistent with the existing SQL plugin convention for its public PPL transport action, `cluster:admin/opensearch/ppl`, and avoids introducing a new top-level action namespace for this sandbox plugin. This keeps the change small while making the action externally configurable and no longer internal-looking.

The index-level authorization check should continue to happen through the separate index-scoped authorization probe from the sandbox analytics authorization work.

## Validation

```bash
JAVA_HOME=/Users/craigperkins/.sdkman/candidates/java/25.0.2-amzn ./gradlew -Dsandbox.enabled=true :sandbox:plugins:test-ppl-frontend:compileJava :sandbox:plugins:test-ppl-frontend:test
```
