### PR TITLE
Use typed builder parser for rollover response

### DIFF
--- a/libs/core/src/main/java/org/opensearch/core/xcontent/AbstractObjectParser.java
+++ b/libs/core/src/main/java/org/opensearch/core/xcontent/AbstractObjectParser.java
@@ -291,6 +291,11 @@ public abstract class AbstractObjectParser<Value, Context> {
         declareField(consumer, XContentParser::text, field, ValueType.STRING);
     }
 
+    public void declareRequiredString(BiConsumer<Value, String> consumer, ParseField field) {
+        declareString(consumer, field);
+        declareRequiredFieldSet(field.getPreferredName());
+    }
+
     /**
      * Declare a field of type {@code T} parsed from string and converted to {@code T} using provided function.
      * Throws if the next token is not a string.
@@ -310,6 +315,21 @@ public abstract class AbstractObjectParser<Value, Context> {
 
     public void declareBoolean(BiConsumer<Value, Boolean> consumer, ParseField field) {
         declareField(consumer, XContentParser::booleanValue, field, ValueType.BOOLEAN);
+    }
+
+    public void declareRequiredBoolean(BiConsumer<Value, Boolean> consumer, ParseField field) {
+        declareBoolean(consumer, field);
+        declareRequiredFieldSet(field.getPreferredName());
+    }
+
+    public <T> void declareRequiredField(
+        BiConsumer<Value, T> consumer,
+        ContextParser<Context, T> parser,
+        ParseField field,
+        ValueType type
+    ) {
+        declareField(consumer, parser, field, type);
+        declareRequiredFieldSet(field.getPreferredName());
     }
 
     public <T> void declareObjectArray(BiConsumer<Value, List<T>> consumer, ContextParser<Context, T> objectParser, ParseField field) {

--- a/libs/x-content/src/test/java/org/opensearch/common/xcontent/ObjectParserTests.java
+++ b/libs/x-content/src/test/java/org/opensearch/common/xcontent/ObjectParserTests.java
@@ -986,6 +986,34 @@ public class ObjectParserTests extends OpenSearchTestCase {
         assertThat(obj.b, equalTo(456L));
     }
 
+    public void testRequiredFieldDeclarations() throws IOException {
+        class TestStruct {
+            private String name;
+            private Boolean enabled;
+
+            private void setName(String value) {
+                this.name = value;
+            }
+
+            private void setEnabled(boolean value) {
+                this.enabled = value;
+            }
+        }
+
+        ObjectParser<TestStruct, Void> objectParser = new ObjectParser<>("foo", true, TestStruct::new);
+        objectParser.declareRequiredString(TestStruct::setName, new ParseField("name"));
+        objectParser.declareRequiredBoolean(TestStruct::setEnabled, new ParseField("enabled"));
+
+        XContentParser parser = createParser(JsonXContent.jsonXContent, "{\"name\": \"test\", \"enabled\": true}");
+        TestStruct obj = objectParser.apply(parser, null);
+        assertThat(obj.name, equalTo("test"));
+        assertThat(obj.enabled, equalTo(true));
+
+        XContentParser missingRequiredParser = createParser(JsonXContent.jsonXContent, "{\"name\": \"test\"}");
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> objectParser.apply(missingRequiredParser, null));
+        assertThat(e.getMessage(), equalTo("Required one of fields [enabled], but none were specified. "));
+    }
+
     private static class TestStruct {
         private Long a;
         private Long b;

--- a/server/src/main/java/org/opensearch/action/admin/indices/rollover/RolloverResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/rollover/RolloverResponse.java
@@ -37,7 +37,6 @@ import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.ParseField;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
-import org.opensearch.core.xcontent.ConstructingObjectParser;
 import org.opensearch.core.xcontent.ObjectParser;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -47,8 +46,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-
-import static org.opensearch.core.xcontent.ConstructingObjectParser.constructorArg;
 
 /**
  * Response object for {@link RolloverRequest} API
@@ -66,29 +63,23 @@ public final class RolloverResponse extends ShardsAcknowledgedResponse implement
     private static final ParseField DRY_RUN = new ParseField("dry_run");
     private static final ParseField ROLLED_OVER = new ParseField("rolled_over");
     private static final ParseField CONDITIONS = new ParseField("conditions");
+    private static final ParseField ACKNOWLEDGED = new ParseField("acknowledged");
 
-    @SuppressWarnings("unchecked")
-    private static final ConstructingObjectParser<RolloverResponse, Void> PARSER = new ConstructingObjectParser<>(
-        "rollover",
-        true,
-        args -> new RolloverResponse(
-            (String) args[0],
-            (String) args[1],
-            (Map<String, Boolean>) args[2],
-            (Boolean) args[3],
-            (Boolean) args[4],
-            (Boolean) args[5],
-            (Boolean) args[6]
-        )
-    );
+    private static final ObjectParser<Builder, Void> PARSER = new ObjectParser<>("rollover", true, Builder::new);
 
     static {
-        PARSER.declareField(constructorArg(), (parser, context) -> parser.text(), OLD_INDEX, ObjectParser.ValueType.STRING);
-        PARSER.declareField(constructorArg(), (parser, context) -> parser.text(), NEW_INDEX, ObjectParser.ValueType.STRING);
-        PARSER.declareObject(constructorArg(), (parser, context) -> parser.map(), CONDITIONS);
-        PARSER.declareField(constructorArg(), (parser, context) -> parser.booleanValue(), DRY_RUN, ObjectParser.ValueType.BOOLEAN);
-        PARSER.declareField(constructorArg(), (parser, context) -> parser.booleanValue(), ROLLED_OVER, ObjectParser.ValueType.BOOLEAN);
-        declareAcknowledgedAndShardsAcknowledgedFields(PARSER);
+        PARSER.declareRequiredString(Builder::oldIndex, OLD_INDEX);
+        PARSER.declareRequiredString(Builder::newIndex, NEW_INDEX);
+        PARSER.declareRequiredField(
+            Builder::conditionStatus,
+            (parser, context) -> parser.map(HashMap::new, XContentParser::booleanValue),
+            CONDITIONS,
+            ObjectParser.ValueType.OBJECT
+        );
+        PARSER.declareRequiredBoolean(Builder::dryRun, DRY_RUN);
+        PARSER.declareRequiredBoolean(Builder::rolledOver, ROLLED_OVER);
+        PARSER.declareRequiredBoolean(Builder::acknowledged, ACKNOWLEDGED);
+        PARSER.declareRequiredBoolean(Builder::shardsAcknowledged, SHARDS_ACKNOWLEDGED);
     }
 
     private final String oldIndex;
@@ -202,7 +193,49 @@ public final class RolloverResponse extends ShardsAcknowledgedResponse implement
     }
 
     public static RolloverResponse fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
+        return PARSER.apply(parser, null).build();
+    }
+
+    private static final class Builder {
+        private String oldIndex;
+        private String newIndex;
+        private Map<String, Boolean> conditionStatus;
+        private boolean dryRun;
+        private boolean rolledOver;
+        private boolean acknowledged;
+        private boolean shardsAcknowledged;
+
+        private void oldIndex(String oldIndex) {
+            this.oldIndex = oldIndex;
+        }
+
+        private void newIndex(String newIndex) {
+            this.newIndex = newIndex;
+        }
+
+        private void conditionStatus(Map<String, Boolean> conditionStatus) {
+            this.conditionStatus = conditionStatus;
+        }
+
+        private void dryRun(boolean dryRun) {
+            this.dryRun = dryRun;
+        }
+
+        private void rolledOver(boolean rolledOver) {
+            this.rolledOver = rolledOver;
+        }
+
+        private void acknowledged(boolean acknowledged) {
+            this.acknowledged = acknowledged;
+        }
+
+        private void shardsAcknowledged(boolean shardsAcknowledged) {
+            this.shardsAcknowledged = shardsAcknowledged;
+        }
+
+        private RolloverResponse build() {
+            return new RolloverResponse(oldIndex, newIndex, conditionStatus, dryRun, rolledOver, acknowledged, shardsAcknowledged);
+        }
     }
 
     @Override


### PR DESCRIPTION
## What changed

Adds required-field convenience declarations to `AbstractObjectParser`:

- `declareRequiredString(...)`
- `declareRequiredBoolean(...)`
- `declareRequiredField(...)`

Updates `RolloverResponse` to use an `ObjectParser` backed by a typed private builder. The parsed fields now map directly to named builder methods instead of relying on positional `Object[] args` entries and unchecked casts.

## Why

This is a small parsing readability POC. `ConstructingObjectParser` works well, but larger response parsers can become brittle because constructor argument order is separated from field declaration order.

The first version of this POC preserved required-field behavior with a separate block of `declareRequiredFieldSet(...)` calls. These new helper methods keep required-ness declared at the field declaration site, which is closer to the readability we want from a builder-style parser.

## Notes

- Preserves unknown-field tolerance by keeping the parser configured with `ignoreUnknownFields=true`.
- Preserves required-field validation through the new required declaration helpers.
- Uses typed parsing for the `conditions` map via `parser.map(HashMap::new, XContentParser::booleanValue)`.

## Validation

- `./gradlew :libs:opensearch-x-content:test --tests org.opensearch.common.xcontent.ObjectParserTests :server:test --tests org.opensearch.action.admin.indices.rollover.RolloverResponseTests`
- `git diff --check`