### PR TITLE
Add XContent builder structural helpers

### DIFF
--- a/libs/core/src/main/java/org/opensearch/core/xcontent/XContentBuilderUtils.java
+++ b/libs/core/src/main/java/org/opensearch/core/xcontent/XContentBuilderUtils.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.core.xcontent;
+
+import java.io.IOException;
+
+/**
+ * Small structural helpers for writing nested {@link XContentBuilder} responses.
+ */
+public final class XContentBuilderUtils {
+
+    private XContentBuilderUtils() {}
+
+    @FunctionalInterface
+    public interface BuilderConsumer {
+        void accept(XContentBuilder builder) throws IOException;
+    }
+
+    @FunctionalInterface
+    public interface BuilderItemConsumer<T> {
+        void accept(XContentBuilder builder, T item) throws IOException;
+    }
+
+    public static XContentBuilder object(XContentBuilder builder, BuilderConsumer body) throws IOException {
+        builder.startObject();
+        body.accept(builder);
+        return builder.endObject();
+    }
+
+    public static XContentBuilder object(XContentBuilder builder, String name, BuilderConsumer body) throws IOException {
+        builder.startObject(name);
+        body.accept(builder);
+        return builder.endObject();
+    }
+
+    public static XContentBuilder array(XContentBuilder builder, String name, BuilderConsumer body) throws IOException {
+        builder.startArray(name);
+        body.accept(builder);
+        return builder.endArray();
+    }
+
+    public static <T> XContentBuilder objectArray(
+        XContentBuilder builder,
+        String name,
+        Iterable<T> items,
+        BuilderItemConsumer<T> itemWriter
+    ) throws IOException {
+        return array(builder, name, arrayBuilder -> {
+            for (T item : items) {
+                object(arrayBuilder, itemBuilder -> itemWriter.accept(itemBuilder, item));
+            }
+        });
+    }
+}

--- a/libs/core/src/test/java/org/opensearch/core/xcontent/XContentBuilderUtilsTests.java
+++ b/libs/core/src/test/java/org/opensearch/core/xcontent/XContentBuilderUtilsTests.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.core.xcontent;
+
+import org.opensearch.core.common.Strings;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+import static org.opensearch.core.xcontent.XContentBuilderUtils.object;
+import static org.opensearch.core.xcontent.XContentBuilderUtils.objectArray;
+
+public class XContentBuilderUtilsTests extends OpenSearchTestCase {
+
+    public void testObjectArrayWritesNestedObjects() {
+        ToXContentObject content = (builder, params) -> object(builder, b -> {
+            b.field("status", "ok");
+            objectArray(b, "items", List.of(new Item("one", 1), new Item("two", 2)), (itemBuilder, item) -> {
+                itemBuilder.field("name", item.name);
+                itemBuilder.field("count", item.count);
+            });
+        });
+
+        assertEquals(
+            "{\"status\":\"ok\",\"items\":[{\"name\":\"one\",\"count\":1},{\"name\":\"two\",\"count\":2}]}",
+            Strings.toString(MediaTypeRegistry.JSON, content)
+        );
+    }
+
+    private record Item(String name, int count) {}
+}

--- a/server/src/main/java/org/opensearch/action/admin/indices/dangling/list/ListDanglingIndicesResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/dangling/list/ListDanglingIndicesResponse.java
@@ -53,6 +53,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.opensearch.core.xcontent.XContentBuilderUtils.objectArray;
+
 /**
  * Models a response to a {@link ListDanglingIndicesRequest}. A list request queries every node in the
  * cluster and aggregates their responses. When the aggregated response is converted to {@link XContent},
@@ -103,21 +105,12 @@ public class ListDanglingIndicesResponse extends BaseNodesResponse<NodeListDangl
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startArray("dangling_indices");
-
-        for (AggregatedDanglingIndexInfo info : resultsByIndexUUID(this.getNodes())) {
-            builder.startObject();
-
-            builder.field("index_name", info.indexName);
-            builder.field("index_uuid", info.indexUUID);
-            builder.timeField("creation_date_millis", "creation_date", info.creationDateMillis);
-
-            builder.array("node_ids", info.nodeIds.toArray(new String[0]));
-
-            builder.endObject();
-        }
-
-        return builder.endArray();
+        return objectArray(builder, "dangling_indices", resultsByIndexUUID(this.getNodes()), (itemBuilder, info) -> {
+            itemBuilder.field("index_name", info.indexName);
+            itemBuilder.field("index_uuid", info.indexUUID);
+            itemBuilder.timeField("creation_date_millis", "creation_date", info.creationDateMillis);
+            itemBuilder.array("node_ids", info.nodeIds.toArray(new String[0]));
+        });
     }
 
     @Override


### PR DESCRIPTION
## What changed

Adds small structural helper methods for writing nested `XContentBuilder` responses:

- `object(...)`
- `array(...)`
- `objectArray(...)`

Uses `objectArray(...)` in `ListDanglingIndicesResponse` to remove the manual `startArray` / `startObject` / `endObject` / `endArray` bookkeeping around the `dangling_indices` response body.

## Why

This is a focused writer-side readability POC. `XContentBuilder` is still the right primitive, but deeply nested response bodies are harder to scan when the response shape is spread across explicit start/end calls. These helpers keep the existing streaming builder model while making common nested structures easier to read and harder to misbalance.

## Notes

This is a companion experiment to the parser-side POC in https://github.com/cwperks/OpenSearch/pull/363. The two PRs are intentionally separate so the writer and parser conventions can be reviewed independently.

## Validation

- `./gradlew :libs:opensearch-core:test --tests org.opensearch.core.xcontent.XContentBuilderUtilsTests :server:compileJava`
- `git diff --cached --check`