### PR TITLE
[WIP] Add remote-cluster module with metadata diff API

### DIFF
--- a/modules/remote-cluster/build.gradle
+++ b/modules/remote-cluster/build.gradle
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+opensearchplugin {
+  name = 'remote-cluster'
+  description = 'Remote cluster module with metadata diff API'
+  classname = 'org.opensearch.remotecluster.RemoteClusterPlugin'
+}
+
+dependencies {
+  api project('spi')
+  testImplementation(project(':test:framework')) {
+    exclude group: 'org.opensearch', module: 'opensearch-core'
+  }
+}

--- a/modules/remote-cluster/spi/build.gradle
+++ b/modules/remote-cluster/spi/build.gradle
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+apply plugin: 'opensearch.build'
+apply plugin: 'opensearch.publish'
+
+base {
+  group = 'org.opensearch.plugin'
+  archivesName = 'remote-cluster-spi'
+}
+
+dependencies {
+  compileOnly project(':server')
+}
+
+disableTasks('forbiddenApisMain')
+
+testingConventions {
+  enabled = false
+}

--- a/modules/remote-cluster/spi/src/main/java/org/opensearch/remotecluster/spi/CategoryDiffResult.java
+++ b/modules/remote-cluster/spi/src/main/java/org/opensearch/remotecluster/spi/CategoryDiffResult.java
@@ -1,0 +1,97 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.remotecluster.spi;
+
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Result of comparing metadata for a single category.
+ */
+public class CategoryDiffResult implements ToXContentObject {
+    private final String category;
+    private final String status;
+    private final int inSync;
+    private final List<String> remoteOnly;
+    private final List<String> localOnly;
+    private final List<DivergedItem> diverged;
+
+    public CategoryDiffResult(
+        String category,
+        String status,
+        int inSync,
+        List<String> remoteOnly,
+        List<String> localOnly,
+        List<DivergedItem> diverged
+    ) {
+        this.category = category;
+        this.status = status;
+        this.inSync = inSync;
+        this.remoteOnly = remoteOnly;
+        this.localOnly = localOnly;
+        this.diverged = diverged;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public int getInSync() {
+        return inSync;
+    }
+
+    public List<String> getRemoteOnly() {
+        return remoteOnly;
+    }
+
+    public List<String> getLocalOnly() {
+        return localOnly;
+    }
+
+    public List<DivergedItem> getDiverged() {
+        return diverged;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startObject();
+        builder.field("status", status);
+        builder.field("in_sync", inSync);
+        builder.field("remote_only", remoteOnly.size());
+        builder.field("local_only", localOnly.size());
+        builder.field("diverged", diverged.size());
+        if (!remoteOnly.isEmpty() || !localOnly.isEmpty() || !diverged.isEmpty()) {
+            builder.startObject("items");
+            if (!remoteOnly.isEmpty()) {
+                builder.field("remote_only", remoteOnly);
+            }
+            if (!localOnly.isEmpty()) {
+                builder.field("local_only", localOnly);
+            }
+            if (!diverged.isEmpty()) {
+                builder.startArray("diverged");
+                for (DivergedItem item : diverged) {
+                    item.toXContent(builder, params);
+                }
+                builder.endArray();
+            }
+            builder.endObject();
+        }
+        builder.endObject();
+        return builder;
+    }
+}

--- a/modules/remote-cluster/spi/src/main/java/org/opensearch/remotecluster/spi/DiffField.java
+++ b/modules/remote-cluster/spi/src/main/java/org/opensearch/remotecluster/spi/DiffField.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.remotecluster.spi;
+
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/**
+ * A specific field that differs between local and remote metadata.
+ */
+public class DiffField implements ToXContentObject {
+    private final String path;
+    private final String local;
+    private final String remote;
+    private final String policy;
+
+    public DiffField(String path, String local, String remote, String policy) {
+        this.path = path;
+        this.local = local;
+        this.remote = remote;
+        this.policy = policy;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getLocal() {
+        return local;
+    }
+
+    public String getRemote() {
+        return remote;
+    }
+
+    public String getPolicy() {
+        return policy;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startObject();
+        builder.field("path", path);
+        builder.field("local", local);
+        builder.field("remote", remote);
+        builder.field("policy", policy);
+        builder.endObject();
+        return builder;
+    }
+}

--- a/modules/remote-cluster/spi/src/main/java/org/opensearch/remotecluster/spi/DivergedItem.java
+++ b/modules/remote-cluster/spi/src/main/java/org/opensearch/remotecluster/spi/DivergedItem.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.remotecluster.spi;
+
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * An item that has diverged between local and remote clusters.
+ */
+public class DivergedItem implements ToXContentObject {
+    private final String name;
+    private final List<DiffField> fields;
+
+    public DivergedItem(String name, List<DiffField> fields) {
+        this.name = name;
+        this.fields = fields;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<DiffField> getFields() {
+        return fields;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startObject();
+        builder.field("name", name);
+        builder.startArray("fields");
+        for (DiffField field : fields) {
+            field.toXContent(builder, params);
+        }
+        builder.endArray();
+        builder.endObject();
+        return builder;
+    }
+}

--- a/modules/remote-cluster/spi/src/main/java/org/opensearch/remotecluster/spi/MetadataDiffExtension.java
+++ b/modules/remote-cluster/spi/src/main/java/org/opensearch/remotecluster/spi/MetadataDiffExtension.java
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.remotecluster.spi;
+
+/**
+ * Extension interface that plugins implement to register metadata diff providers.
+ * Plugins that want to contribute metadata categories to the diff API should
+ * implement this interface in their Plugin class.
+ */
+public interface MetadataDiffExtension {
+    /** Return the metadata diff provider for this plugin's category */
+    MetadataDiffProvider getMetadataDiffProvider();
+}

--- a/modules/remote-cluster/spi/src/main/java/org/opensearch/remotecluster/spi/MetadataDiffProvider.java
+++ b/modules/remote-cluster/spi/src/main/java/org/opensearch/remotecluster/spi/MetadataDiffProvider.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.remotecluster.spi;
+
+import org.opensearch.cluster.metadata.Metadata;
+
+/**
+ * SPI interface for providing metadata diff capabilities for a specific category.
+ * Plugins implement this to contribute their own metadata comparison logic.
+ */
+public interface MetadataDiffProvider {
+    /** The category name (e.g., "templates", "security_roles", "ism_policies") */
+    String category();
+
+    /** Compare local and remote metadata for this category */
+    CategoryDiffResult diff(Metadata local, Metadata remote);
+}

--- a/modules/remote-cluster/src/main/java/org/opensearch/remotecluster/RemoteClusterPlugin.java
+++ b/modules/remote-cluster/src/main/java/org/opensearch/remotecluster/RemoteClusterPlugin.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.remotecluster;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.IndexScopedSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.SettingsFilter;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.remotecluster.action.MetadataDiffAction;
+import org.opensearch.remotecluster.action.TransportMetadataDiffAction;
+import org.opensearch.remotecluster.rest.RestMetadataDiffAction;
+import org.opensearch.remotecluster.spi.MetadataDiffExtension;
+import org.opensearch.remotecluster.spi.MetadataDiffProvider;
+import org.opensearch.plugins.ActionPlugin;
+import org.opensearch.plugins.ExtensiblePlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.rest.RestController;
+import org.opensearch.rest.RestHandler;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Cross-cluster replication module with metadata diff API.
+ */
+public class RemoteClusterPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin {
+
+    private final List<MetadataDiffProvider> extensionProviders = new ArrayList<>();
+
+    @Override
+    public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
+        return Collections.singletonList(new ActionHandler<>(MetadataDiffAction.INSTANCE, TransportMetadataDiffAction.class));
+    }
+
+    @Override
+    public List<RestHandler> getRestHandlers(
+        Settings settings,
+        RestController restController,
+        ClusterSettings clusterSettings,
+        IndexScopedSettings indexScopedSettings,
+        SettingsFilter settingsFilter,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        Supplier<DiscoveryNodes> nodesInCluster
+    ) {
+        return Collections.singletonList(new RestMetadataDiffAction());
+    }
+
+    @Override
+    public void loadExtensions(ExtensionLoader loader) {
+        for (MetadataDiffExtension extension : loader.loadExtensions(MetadataDiffExtension.class)) {
+            extensionProviders.add(extension.getMetadataDiffProvider());
+        }
+    }
+
+    public List<MetadataDiffProvider> getExtensionProviders() {
+        return Collections.unmodifiableList(extensionProviders);
+    }
+}

--- a/modules/remote-cluster/src/main/java/org/opensearch/remotecluster/action/MetadataDiffAction.java
+++ b/modules/remote-cluster/src/main/java/org/opensearch/remotecluster/action/MetadataDiffAction.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.remotecluster.action;
+
+import org.opensearch.action.ActionType;
+
+/**
+ * Action type for metadata diff between local and remote clusters.
+ */
+public class MetadataDiffAction extends ActionType<MetadataDiffResponse> {
+    public static final MetadataDiffAction INSTANCE = new MetadataDiffAction();
+    public static final String NAME = "cluster:admin/remotes/metadata/diff";
+
+    private MetadataDiffAction() {
+        super(NAME, MetadataDiffResponse::new);
+    }
+}

--- a/modules/remote-cluster/src/main/java/org/opensearch/remotecluster/action/MetadataDiffRequest.java
+++ b/modules/remote-cluster/src/main/java/org/opensearch/remotecluster/action/MetadataDiffRequest.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.remotecluster.action;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.ValidateActions;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * Request for metadata diff between local and remote clusters.
+ */
+public class MetadataDiffRequest extends ActionRequest {
+    private final String connectionName;
+    private final Set<String> categories;
+
+    public MetadataDiffRequest(String connectionName, Set<String> categories) {
+        this.connectionName = connectionName;
+        this.categories = categories;
+    }
+
+    public MetadataDiffRequest(StreamInput in) throws IOException {
+        super(in);
+        this.connectionName = in.readString();
+        this.categories = in.readSet(StreamInput::readString);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(connectionName);
+        out.writeStringCollection(categories);
+    }
+
+    public String getConnectionName() {
+        return connectionName;
+    }
+
+    public Set<String> getCategories() {
+        return categories;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (connectionName == null || connectionName.isBlank()) {
+            validationException = ValidateActions.addValidationError("connection_name must not be empty", validationException);
+        }
+        return validationException;
+    }
+}

--- a/modules/remote-cluster/src/main/java/org/opensearch/remotecluster/action/MetadataDiffResponse.java
+++ b/modules/remote-cluster/src/main/java/org/opensearch/remotecluster/action/MetadataDiffResponse.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.remotecluster.action;
+
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.remotecluster.spi.CategoryDiffResult;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Response containing metadata diff results.
+ */
+public class MetadataDiffResponse extends ActionResponse implements ToXContentObject {
+    private final String connectionName;
+    private final long remoteMetadataVersion;
+    private final long localMetadataVersion;
+    private final List<CategoryDiffResult> categories;
+
+    public MetadataDiffResponse(
+        String connectionName,
+        long remoteMetadataVersion,
+        long localMetadataVersion,
+        List<CategoryDiffResult> categories
+    ) {
+        this.connectionName = connectionName;
+        this.remoteMetadataVersion = remoteMetadataVersion;
+        this.localMetadataVersion = localMetadataVersion;
+        this.categories = categories;
+    }
+
+    public MetadataDiffResponse(StreamInput in) throws IOException {
+        super(in);
+        this.connectionName = in.readString();
+        this.remoteMetadataVersion = in.readVLong();
+        this.localMetadataVersion = in.readVLong();
+        this.categories = List.of(); // TODO: full serialization
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(connectionName);
+        out.writeVLong(remoteMetadataVersion);
+        out.writeVLong(localMetadataVersion);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startObject();
+        builder.field("connection_name", connectionName);
+        builder.field("remote_metadata_version", remoteMetadataVersion);
+        builder.field("local_metadata_version", localMetadataVersion);
+        builder.startObject("categories");
+        for (CategoryDiffResult cat : categories) {
+            builder.field(cat.getCategory());
+            cat.toXContent(builder, params);
+        }
+        builder.endObject();
+        builder.endObject();
+        return builder;
+    }
+}

--- a/modules/remote-cluster/src/main/java/org/opensearch/remotecluster/action/TransportMetadataDiffAction.java
+++ b/modules/remote-cluster/src/main/java/org/opensearch/remotecluster/action/TransportMetadataDiffAction.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.remotecluster.action;
+
+import org.opensearch.action.admin.cluster.state.ClusterStateAction;
+import org.opensearch.action.admin.cluster.state.ClusterStateRequest;
+import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.remotecluster.provider.IndexMetadataDiffProvider;
+import org.opensearch.remotecluster.provider.IngestPipelineDiffProvider;
+import org.opensearch.remotecluster.provider.LegacyTemplateDiffProvider;
+import org.opensearch.remotecluster.spi.CategoryDiffResult;
+import org.opensearch.remotecluster.spi.MetadataDiffProvider;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Transport action that fetches remote cluster metadata and computes diff.
+ */
+public class TransportMetadataDiffAction extends HandledTransportAction<MetadataDiffRequest, MetadataDiffResponse> {
+
+    private final ClusterService clusterService;
+    private final Client client;
+    private final Map<String, MetadataDiffProvider> providers;
+
+    @Inject
+    public TransportMetadataDiffAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ClusterService clusterService,
+        Client client
+    ) {
+        super(MetadataDiffAction.NAME, transportService, actionFilters, MetadataDiffRequest::new);
+        this.clusterService = clusterService;
+        this.client = client;
+        this.providers = new LinkedHashMap<>();
+        providers.put("templates", new LegacyTemplateDiffProvider());
+        providers.put("ingest_pipelines", new IngestPipelineDiffProvider());
+        providers.put("indices", new IndexMetadataDiffProvider());
+    }
+
+    public Set<String> getSupportedCategories() {
+        return providers.keySet();
+    }
+
+    @Override
+    protected void doExecute(Task task, MetadataDiffRequest request, ActionListener<MetadataDiffResponse> listener) {
+        ClusterStateRequest remoteRequest = new ClusterStateRequest().clear().metadata(true).customs(true);
+        Client remoteClient = client.getRemoteClusterClient(request.getConnectionName());
+
+        remoteClient.execute(ClusterStateAction.INSTANCE, remoteRequest, ActionListener.wrap((ClusterStateResponse remoteStateResponse) -> {
+            try {
+                Metadata localMetadata = clusterService.state().metadata();
+                Metadata remoteMetadata = remoteStateResponse.getState().metadata();
+                List<CategoryDiffResult> results = new ArrayList<>();
+                for (Map.Entry<String, MetadataDiffProvider> entry : providers.entrySet()) {
+                    if (request.getCategories().contains(entry.getKey())) {
+                        results.add(entry.getValue().diff(localMetadata, remoteMetadata));
+                    }
+                }
+                listener.onResponse(
+                    new MetadataDiffResponse(request.getConnectionName(), remoteMetadata.version(), localMetadata.version(), results)
+                );
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        }, listener::onFailure));
+    }
+}

--- a/modules/remote-cluster/src/main/java/org/opensearch/remotecluster/provider/IndexMetadataDiffProvider.java
+++ b/modules/remote-cluster/src/main/java/org/opensearch/remotecluster/provider/IndexMetadataDiffProvider.java
@@ -1,0 +1,137 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.remotecluster.provider;
+
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.remotecluster.spi.CategoryDiffResult;
+import org.opensearch.remotecluster.spi.DiffField;
+import org.opensearch.remotecluster.spi.DivergedItem;
+import org.opensearch.remotecluster.spi.MetadataDiffProvider;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Compares index metadata between local and remote clusters.
+ */
+public class IndexMetadataDiffProvider implements MetadataDiffProvider {
+
+    private static final Set<String> STRIPPED_SETTINGS = Set.of(
+        "index.uuid",
+        "index.version.created",
+        "index.version.upgraded",
+        "index.creation_date",
+        "index.provided_name",
+        "index.resize.source.uuid",
+        "index.resize.source.name"
+    );
+    private static final List<String> STRIPPED_PREFIXES = List.of("index.routing.allocation.");
+    private static final Set<String> CONDITIONAL_SETTINGS = Set.of("index.number_of_replicas");
+
+    @Override
+    public String category() {
+        return "indices";
+    }
+
+    @Override
+    public CategoryDiffResult diff(Metadata local, Metadata remote) {
+        Set<String> localIndices = local.indices()
+            .keySet()
+            .stream()
+            .filter(name -> isReplicable(local.index(name)))
+            .collect(Collectors.toSet());
+        Set<String> remoteIndices = remote.indices()
+            .keySet()
+            .stream()
+            .filter(name -> isReplicable(remote.index(name)))
+            .collect(Collectors.toSet());
+
+        Set<String> remoteOnlySet = new HashSet<>(remoteIndices);
+        remoteOnlySet.removeAll(localIndices);
+        Set<String> localOnlySet = new HashSet<>(localIndices);
+        localOnlySet.removeAll(remoteIndices);
+        Set<String> common = new HashSet<>(localIndices);
+        common.retainAll(remoteIndices);
+
+        int inSync = 0;
+        List<DivergedItem> diverged = new ArrayList<>();
+        for (String name : common.stream().sorted().toList()) {
+            List<DiffField> fields = diffIndex(local.index(name), remote.index(name));
+            if (fields.isEmpty()) {
+                inSync++;
+            } else {
+                diverged.add(new DivergedItem(name, fields));
+            }
+        }
+
+        return new CategoryDiffResult(
+            category(),
+            "compared",
+            inSync,
+            remoteOnlySet.stream().sorted().toList(),
+            localOnlySet.stream().sorted().toList(),
+            diverged
+        );
+    }
+
+    private List<DiffField> diffIndex(IndexMetadata local, IndexMetadata remote) {
+        List<DiffField> fields = new ArrayList<>();
+
+        String localMapping = local.mapping() != null ? local.mapping().source().string() : null;
+        String remoteMapping = remote.mapping() != null ? remote.mapping().source().string() : null;
+        if (localMapping != null ? !localMapping.equals(remoteMapping) : remoteMapping != null) {
+            fields.add(new DiffField("mappings", "[differs]", "[differs]", "included"));
+        }
+
+        Set<String> allKeys = new HashSet<>();
+        allKeys.addAll(local.getSettings().keySet());
+        allKeys.addAll(remote.getSettings().keySet());
+
+        for (String key : allKeys.stream().filter(k -> !isStripped(k)).sorted().toList()) {
+            String localVal = local.getSettings().get(key);
+            String remoteVal = remote.getSettings().get(key);
+            if (localVal != null ? !localVal.equals(remoteVal) : remoteVal != null) {
+                fields.add(new DiffField("settings." + key, localVal, remoteVal, policyFor(key)));
+            }
+        }
+
+        Set<String> localAliases = local.getAliases().keySet();
+        Set<String> remoteAliases = remote.getAliases().keySet();
+        Set<String> aliasRemoteOnly = new HashSet<>(remoteAliases);
+        aliasRemoteOnly.removeAll(localAliases);
+        for (String alias : aliasRemoteOnly.stream().sorted().toList()) {
+            fields.add(new DiffField("aliases." + alias, null, "present", "included"));
+        }
+        Set<String> aliasLocalOnly = new HashSet<>(localAliases);
+        aliasLocalOnly.removeAll(remoteAliases);
+        for (String alias : aliasLocalOnly.stream().sorted().toList()) {
+            fields.add(new DiffField("aliases." + alias, "present", null, "included"));
+        }
+
+        return fields;
+    }
+
+    private boolean isReplicable(IndexMetadata im) {
+        String name = im.getIndex().getName();
+        return !name.startsWith(".") && !im.isSystem() && !im.getSettings().getAsBoolean("index.hidden", false);
+    }
+
+    private boolean isStripped(String key) {
+        if (STRIPPED_SETTINGS.contains(key)) return true;
+        return STRIPPED_PREFIXES.stream().anyMatch(key::startsWith);
+    }
+
+    private String policyFor(String key) {
+        return CONDITIONAL_SETTINGS.contains(key) ? "conditional" : "included";
+    }
+}

--- a/modules/remote-cluster/src/main/java/org/opensearch/remotecluster/provider/IngestPipelineDiffProvider.java
+++ b/modules/remote-cluster/src/main/java/org/opensearch/remotecluster/provider/IngestPipelineDiffProvider.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.remotecluster.provider;
+
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.remotecluster.spi.CategoryDiffResult;
+import org.opensearch.remotecluster.spi.DiffField;
+import org.opensearch.remotecluster.spi.DivergedItem;
+import org.opensearch.remotecluster.spi.MetadataDiffProvider;
+import org.opensearch.ingest.IngestMetadata;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Compares ingest pipelines between local and remote clusters.
+ */
+public class IngestPipelineDiffProvider implements MetadataDiffProvider {
+    @Override
+    public String category() {
+        return "ingest_pipelines";
+    }
+
+    @Override
+    public CategoryDiffResult diff(Metadata local, Metadata remote) {
+        IngestMetadata localIngest = local.custom(IngestMetadata.TYPE);
+        IngestMetadata remoteIngest = remote.custom(IngestMetadata.TYPE);
+
+        Set<String> localNames = localIngest != null ? localIngest.getPipelines().keySet() : Collections.emptySet();
+        Set<String> remoteNames = remoteIngest != null ? remoteIngest.getPipelines().keySet() : Collections.emptySet();
+
+        Set<String> remoteOnlySet = new HashSet<>(remoteNames);
+        remoteOnlySet.removeAll(localNames);
+        Set<String> localOnlySet = new HashSet<>(localNames);
+        localOnlySet.removeAll(remoteNames);
+        Set<String> common = new HashSet<>(localNames);
+        common.retainAll(remoteNames);
+
+        int inSync = 0;
+        List<DivergedItem> diverged = new ArrayList<>();
+        for (String name : common) {
+            if (localIngest.getPipelines().get(name).getConfigAsMap().equals(remoteIngest.getPipelines().get(name).getConfigAsMap())) {
+                inSync++;
+            } else {
+                diverged.add(new DivergedItem(name, List.of(new DiffField("content", "[differs]", "[differs]", "included"))));
+            }
+        }
+
+        return new CategoryDiffResult(
+            category(),
+            "compared",
+            inSync,
+            remoteOnlySet.stream().sorted().toList(),
+            localOnlySet.stream().sorted().toList(),
+            diverged
+        );
+    }
+}

--- a/modules/remote-cluster/src/main/java/org/opensearch/remotecluster/provider/LegacyTemplateDiffProvider.java
+++ b/modules/remote-cluster/src/main/java/org/opensearch/remotecluster/provider/LegacyTemplateDiffProvider.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.remotecluster.provider;
+
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.remotecluster.spi.CategoryDiffResult;
+import org.opensearch.remotecluster.spi.DiffField;
+import org.opensearch.remotecluster.spi.DivergedItem;
+import org.opensearch.remotecluster.spi.MetadataDiffProvider;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Compares legacy index templates between local and remote clusters.
+ */
+public class LegacyTemplateDiffProvider implements MetadataDiffProvider {
+    @Override
+    public String category() {
+        return "templates";
+    }
+
+    @Override
+    public CategoryDiffResult diff(Metadata local, Metadata remote) {
+        Set<String> localNames = local.templates().keySet();
+        Set<String> remoteNames = remote.templates().keySet();
+
+        Set<String> remoteOnlySet = new HashSet<>(remoteNames);
+        remoteOnlySet.removeAll(localNames);
+        Set<String> localOnlySet = new HashSet<>(localNames);
+        localOnlySet.removeAll(remoteNames);
+        Set<String> common = new HashSet<>(localNames);
+        common.retainAll(remoteNames);
+
+        int inSync = 0;
+        List<DivergedItem> diverged = new ArrayList<>();
+        for (String name : common) {
+            if (local.templates().get(name).equals(remote.templates().get(name))) {
+                inSync++;
+            } else {
+                diverged.add(new DivergedItem(name, List.of(new DiffField("content", "[differs]", "[differs]", "included"))));
+            }
+        }
+
+        return new CategoryDiffResult(
+            category(),
+            "compared",
+            inSync,
+            remoteOnlySet.stream().sorted().toList(),
+            localOnlySet.stream().sorted().toList(),
+            diverged
+        );
+    }
+}

--- a/modules/remote-cluster/src/main/java/org/opensearch/remotecluster/rest/RestMetadataDiffAction.java
+++ b/modules/remote-cluster/src/main/java/org/opensearch/remotecluster/rest/RestMetadataDiffAction.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.remotecluster.rest;
+
+import org.opensearch.remotecluster.action.MetadataDiffAction;
+import org.opensearch.remotecluster.action.MetadataDiffRequest;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestToXContentListener;
+import org.opensearch.transport.client.node.NodeClient;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+
+/**
+ * REST handler for the metadata diff API.
+ */
+public class RestMetadataDiffAction extends BaseRestHandler {
+
+    @Override
+    public String getName() {
+        return "cross_cluster_metadata_diff";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return unmodifiableList(asList(new Route(RestRequest.Method.GET, "/_remotes/{connection}/_metadata_diff")));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        String connection = request.param("connection");
+        String categoriesParam = request.param("categories", "");
+        Set<String> categories;
+        if (categoriesParam.isBlank()) {
+            categories = Set.of("templates", "ingest_pipelines", "indices");
+        } else {
+            categories = Set.of(categoriesParam.split(","));
+        }
+        MetadataDiffRequest diffRequest = new MetadataDiffRequest(connection, categories);
+        return channel -> client.execute(MetadataDiffAction.INSTANCE, diffRequest, new RestToXContentListener<>(channel));
+    }
+}

--- a/modules/remote-cluster/src/test/java/org/opensearch/remotecluster/action/MetadataDiffTests.java
+++ b/modules/remote-cluster/src/test/java/org/opensearch/remotecluster/action/MetadataDiffTests.java
@@ -1,0 +1,127 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.remotecluster.action;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.IndexTemplateMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.remotecluster.provider.IndexMetadataDiffProvider;
+import org.opensearch.remotecluster.provider.IngestPipelineDiffProvider;
+import org.opensearch.remotecluster.provider.LegacyTemplateDiffProvider;
+import org.opensearch.remotecluster.spi.CategoryDiffResult;
+import org.opensearch.ingest.IngestMetadata;
+import org.opensearch.ingest.PipelineConfiguration;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MetadataDiffTests extends OpenSearchTestCase {
+
+    public void testTemplatesInSync() {
+        IndexTemplateMetadata template = IndexTemplateMetadata.builder("my-template").patterns(List.of("test-*")).build();
+        Metadata local = Metadata.builder().put(template).build();
+        Metadata remote = Metadata.builder().put(template).build();
+
+        CategoryDiffResult result = new LegacyTemplateDiffProvider().diff(local, remote);
+        assertEquals("compared", result.getStatus());
+        assertEquals(1, result.getInSync());
+        assertTrue(result.getRemoteOnly().isEmpty());
+        assertTrue(result.getDiverged().isEmpty());
+    }
+
+    public void testTemplatesRemoteOnly() {
+        IndexTemplateMetadata template = IndexTemplateMetadata.builder("remote-template").patterns(List.of("remote-*")).build();
+        Metadata local = Metadata.builder().build();
+        Metadata remote = Metadata.builder().put(template).build();
+
+        CategoryDiffResult result = new LegacyTemplateDiffProvider().diff(local, remote);
+        assertEquals(1, result.getRemoteOnly().size());
+        assertEquals("remote-template", result.getRemoteOnly().get(0));
+    }
+
+    public void testIndicesRemoteOnly() {
+        Metadata local = Metadata.builder().build();
+        IndexMetadata indexMetadata = IndexMetadata.builder("test-index")
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+            )
+            .build();
+        Metadata remote = Metadata.builder().put(indexMetadata, false).build();
+
+        CategoryDiffResult result = new IndexMetadataDiffProvider().diff(local, remote);
+        assertEquals(1, result.getRemoteOnly().size());
+        assertEquals("test-index", result.getRemoteOnly().get(0));
+    }
+
+    public void testIndicesDivergedReplicas() {
+        Settings baseSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .build();
+        IndexMetadata localIndex = IndexMetadata.builder("test-index")
+            .settings(Settings.builder().put(baseSettings).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1))
+            .build();
+        IndexMetadata remoteIndex = IndexMetadata.builder("test-index")
+            .settings(Settings.builder().put(baseSettings).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 2))
+            .build();
+        Metadata local = Metadata.builder().put(localIndex, false).build();
+        Metadata remote = Metadata.builder().put(remoteIndex, false).build();
+
+        CategoryDiffResult result = new IndexMetadataDiffProvider().diff(local, remote);
+        assertEquals(0, result.getInSync());
+        assertEquals(1, result.getDiverged().size());
+        assertEquals("test-index", result.getDiverged().get(0).getName());
+        assertTrue(
+            result.getDiverged()
+                .get(0)
+                .getFields()
+                .stream()
+                .anyMatch(f -> f.getPath().contains("number_of_replicas") && "conditional".equals(f.getPolicy()))
+        );
+    }
+
+    public void testSystemIndicesExcluded() {
+        IndexMetadata systemIndex = IndexMetadata.builder(".system-index")
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+            )
+            .system(true)
+            .build();
+        Metadata local = Metadata.builder().build();
+        Metadata remote = Metadata.builder().put(systemIndex, false).build();
+
+        CategoryDiffResult result = new IndexMetadataDiffProvider().diff(local, remote);
+        assertTrue(result.getRemoteOnly().isEmpty());
+    }
+
+    public void testIngestPipelinesRemoteOnly() {
+        Map<String, PipelineConfiguration> pipelines = new HashMap<>();
+        pipelines.put("my-pipeline", new PipelineConfiguration("my-pipeline", new BytesArray("{\"processors\":[]}"), MediaTypeRegistry.JSON));
+        IngestMetadata ingestMetadata = new IngestMetadata(pipelines);
+
+        Metadata local = Metadata.builder().build();
+        Metadata remote = Metadata.builder().putCustom(IngestMetadata.TYPE, ingestMetadata).build();
+
+        CategoryDiffResult result = new IngestPipelineDiffProvider().diff(local, remote);
+        assertEquals(1, result.getRemoteOnly().size());
+        assertEquals("my-pipeline", result.getRemoteOnly().get(0));
+    }
+}


### PR DESCRIPTION
## WIP: Remote Cluster Module with Metadata Diff API

Introduces a new core module (`modules/remote-cluster/`) that provides a metadata diff API for comparing cluster state between local and remote clusters.

### Architecture

```
modules/remote-cluster/
├── spi/          # Interfaces for plugin extensibility
└── src/          # Core implementation + built-in providers
```

### SPI (for plugin authors)

Plugins implement `MetadataDiffExtension` to register custom diff categories:
```java
public class SecurityPlugin extends Plugin implements MetadataDiffExtension {
    public MetadataDiffProvider getMetadataDiffProvider() {
        return new SecurityRoleDiffProvider();
    }
}
```

### REST API

```
GET /_remotes/{connection}/_metadata_diff
GET /_remotes/{connection}/_metadata_diff?categories=indices,templates
```

### Built-in categories

- `templates` — legacy index templates
- `ingest_pipelines` — ingest pipeline configurations
- `indices` — index metadata (mappings, settings, aliases) with field-level diff and policy classification

### Status

- [x] SPI interfaces
- [x] Core transport action + REST handler
- [x] Built-in providers (templates, ingest_pipelines, indices)
- [x] Unit tests (all passing)
- [ ] Integration tests with remote cluster
- [ ] Javadoc
- [ ] Spotless formatting