### PR TITLE
Add Thread.stop agent policy check

### DIFF
--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/Agent.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/Agent.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.javaagent;
 
+import org.opensearch.javaagent.bootstrap.ThreadStopInterceptor;
 import org.opensearch.javaagent.bootstrap.internal.SubjectInterceptor;
 
 import javax.security.auth.Subject;
@@ -112,6 +113,12 @@ public class Agent {
             .transform(
                 (b, typeDescription, classLoader, module, pd) -> b.visit(
                     Advice.to(RuntimeHaltInterceptor.class).on(ElementMatchers.named("halt"))
+                )
+            )
+            .type(ElementMatchers.is(java.lang.Thread.class))
+            .transform(
+                (b, typeDescription, classLoader, module, pd) -> b.visit(
+                    Advice.to(ThreadStopInterceptor.class).on(ElementMatchers.named("stop").and(ElementMatchers.takesArguments(0)))
                 )
             );
 

--- a/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/AgentTests.java
+++ b/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/AgentTests.java
@@ -20,4 +20,10 @@ public class AgentTests extends AgentTestCase {
     public void testRuntimeHaltIsForbidden() {
         Runtime.getRuntime().halt(0);
     }
+
+    @SuppressWarnings("removal")
+    @Test(expected = SecurityException.class)
+    public void testThreadStopIsForbidden() {
+        new Thread(() -> {}).stop();
+    }
 }

--- a/libs/agent-sm/bootstrap/build.gradle
+++ b/libs/agent-sm/bootstrap/build.gradle
@@ -22,6 +22,7 @@ tasks.named('forbiddenApisMain').configure {
 
 dependencies {
   compileOnly project(":libs:agent-sm:agent-policy")
+  compileOnly "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
 }
 
 test.enabled = false

--- a/libs/agent-sm/bootstrap/src/main/java/org/opensearch/javaagent/bootstrap/ThreadStopInterceptor.java
+++ b/libs/agent-sm/bootstrap/src/main/java/org/opensearch/javaagent/bootstrap/ThreadStopInterceptor.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.javaagent.bootstrap;
+
+import net.bytebuddy.asm.Advice;
+
+/**
+ * {@link Thread#stop} interceptor
+ */
+public class ThreadStopInterceptor {
+    /**
+     * ThreadStopInterceptor
+     */
+    public ThreadStopInterceptor() {}
+
+    /**
+     * Interceptor
+     */
+    @Advice.OnMethodEnter
+    public static void intercept() {
+        if (AgentPolicy.getPolicy() == null) {
+            return; /* noop */
+        }
+
+        AgentPolicy.checkPermission(new RuntimePermission("stopThread"));
+    }
+}

--- a/server/src/main/java/org/opensearch/bootstrap/OpenSearchPolicy.java
+++ b/server/src/main/java/org/opensearch/bootstrap/OpenSearchPolicy.java
@@ -68,6 +68,7 @@ final class OpenSearchPolicy extends Policy {
     final PermissionCollection dynamic;
     final PermissionCollection dataPathPermission;
     final Map<String, Policy> plugins;
+    final boolean filterBadDefaults;
 
     OpenSearchPolicy(
         Map<String, URL> codebases,
@@ -79,6 +80,7 @@ final class OpenSearchPolicy extends Policy {
         this.template = Security.readPolicy(getClass().getResource(POLICY_RESOURCE), codebases);
         this.dataPathPermission = dataPathPermission;
         this.untrusted = Security.readPolicy(getClass().getResource(UNTRUSTED_RESOURCE), Collections.emptyMap());
+        this.filterBadDefaults = filterBadDefaults;
         if (filterBadDefaults) {
             this.system = new SystemPolicy(Policy.getPolicy());
         } else {
@@ -91,7 +93,9 @@ final class OpenSearchPolicy extends Policy {
     @Override
     @SuppressForbidden(reason = "fast equals check is desired")
     public boolean implies(ProtectionDomain domain, Permission permission) {
-        CodeSource codeSource = domain.getCodeSource();
+        ProtectionDomain policyDomain = filterBadDefaults && isBadDefaultPermission(permission) ? withoutStaticPermissions(domain) : domain;
+
+        CodeSource codeSource = policyDomain.getCodeSource();
         // codesource can be null when reducing privileges via doPrivileged()
         if (codeSource == null) {
             return false;
@@ -103,12 +107,12 @@ final class OpenSearchPolicy extends Policy {
         if (location != null) {
             // run scripts with limited permissions
             if (BootstrapInfo.UNTRUSTED_CODEBASE.equals(location.getFile())) {
-                return untrusted.implies(domain, permission);
+                return untrusted.implies(policyDomain, permission);
             }
             // check for an additional plugin permission: plugin policy is
             // only consulted for its codesources.
             Policy plugin = plugins.get(location.getFile());
-            if (plugin != null && plugin.implies(domain, permission)) {
+            if (plugin != null && plugin.implies(policyDomain, permission)) {
                 return true;
             }
         }
@@ -132,7 +136,7 @@ final class OpenSearchPolicy extends Policy {
         }
 
         // otherwise defer to template + dynamic file permissions
-        return template.implies(domain, permission) || dynamic.implies(permission) || system.implies(domain, permission);
+        return template.implies(policyDomain, permission) || dynamic.implies(permission) || system.implies(policyDomain, permission);
     }
 
     /**
@@ -210,6 +214,14 @@ final class OpenSearchPolicy extends Policy {
 
     }
 
+    private static boolean isBadDefaultPermission(Permission permission) {
+        return BAD_DEFAULT_NUMBER_ONE.implies(permission) || BAD_DEFAULT_NUMBER_TWO.implies(permission);
+    }
+
+    private static ProtectionDomain withoutStaticPermissions(ProtectionDomain domain) {
+        return new ProtectionDomain(domain.getCodeSource(), null);
+    }
+
     // default policy file states:
     // "It is strongly recommended that you either remove this permission
     // from this policy file or further restrict it to code sources
@@ -239,7 +251,7 @@ final class OpenSearchPolicy extends Policy {
 
         @Override
         public boolean implies(ProtectionDomain domain, Permission permission) {
-            if (BAD_DEFAULT_NUMBER_ONE.implies(permission) || BAD_DEFAULT_NUMBER_TWO.implies(permission)) {
+            if (isBadDefaultPermission(permission)) {
                 return false;
             }
             return delegate.implies(domain, permission);

--- a/server/src/test/java/org/opensearch/bootstrap/OpenSearchPolicyTests.java
+++ b/server/src/test/java/org/opensearch/bootstrap/OpenSearchPolicyTests.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.bootstrap;
+
+import org.opensearch.secure_sm.policy.Policy;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.net.SocketPermission;
+import java.net.URL;
+import java.security.CodeSource;
+import java.security.Permission;
+import java.security.Permissions;
+import java.security.ProtectionDomain;
+import java.security.cert.Certificate;
+import java.util.Collections;
+import java.util.Map;
+
+public class OpenSearchPolicyTests extends OpenSearchTestCase {
+
+    public void testFilterBadDefaultsBlocksStopThreadPermission() throws Exception {
+        Permission permission = new RuntimePermission("stopThread");
+
+        assertFalse(newPolicy(true).implies(domainWithStaticPermission(permission), permission));
+        assertTrue(newPolicy(false).implies(domainWithStaticPermission(permission), permission));
+    }
+
+    public void testFilterBadDefaultsBlocksLocalhostDynamicListenPermission() throws Exception {
+        Permission permission = new SocketPermission("localhost:0", "listen");
+
+        assertFalse(newPolicy(true).implies(domainWithStaticPermission(permission), permission));
+        assertTrue(newPolicy(false).implies(domainWithStaticPermission(permission), permission));
+    }
+
+    public void testFilterBadDefaultsAllowsOtherFallbackPermissions() throws Exception {
+        Permission permission = new RuntimePermission("getClassLoader");
+
+        assertTrue(newPolicy(true).implies(domainWithStaticPermission(permission), permission));
+    }
+
+    public void testFilterBadDefaultsAllowsExplicitPluginPolicyGrant() throws Exception {
+        Permission permission = new RuntimePermission("stopThread");
+        URL pluginUrl = new URL("file:/plugin.jar");
+        ProtectionDomain pluginDomain = domainWithStaticPermission(pluginUrl, permission);
+        Policy pluginPolicy = new Policy() {
+            @Override
+            public boolean implies(ProtectionDomain domain, Permission requestedPermission) {
+                return domain.getCodeSource().getLocation().equals(pluginUrl) && requestedPermission.equals(permission);
+            }
+        };
+
+        assertTrue(newPolicy(true, Map.of(pluginUrl.getFile(), pluginPolicy)).implies(pluginDomain, permission));
+    }
+
+    private static OpenSearchPolicy newPolicy(boolean filterBadDefaults) {
+        return newPolicy(filterBadDefaults, Collections.emptyMap());
+    }
+
+    private static OpenSearchPolicy newPolicy(boolean filterBadDefaults, Map<String, Policy> plugins) {
+        return new OpenSearchPolicy(Collections.emptyMap(), new Permissions(), plugins, filterBadDefaults, new Permissions());
+    }
+
+    private static ProtectionDomain domainWithStaticPermission(Permission permission) throws Exception {
+        return domainWithStaticPermission(new URL("file:/test.jar"), permission);
+    }
+
+    private static ProtectionDomain domainWithStaticPermission(URL location, Permission permission) {
+        Permissions permissions = new Permissions();
+        permissions.add(permission);
+        return new ProtectionDomain(new CodeSource(location, (Certificate[]) null), permissions);
+    }
+}


### PR DESCRIPTION
## Summary
- Add a java agent interceptor for Thread.stop that checks RuntimePermission("stopThread") through AgentPolicy
- Keep the Thread.stop advice in the agent bootstrap jar so transformed java.lang.Thread can resolve it
- Preserve bad-default filtering when OpenSearchPolicy evaluates static ProtectionDomain permissions
- Add focused tests for both the real agent interception path and OpenSearchPolicy bad-default filtering

## Testing
- ./gradlew :libs:opensearch-agent-sm:agent:test --tests org.opensearch.javaagent.AgentTests
- ./gradlew :libs:opensearch-agent-sm:agent:test :server:test --tests org.opensearch.bootstrap.OpenSearchPolicyTests
- ./gradlew :libs:opensearch-agent-sm:agent:spotlessApply :libs:opensearch-agent-sm:bootstrap:spotlessApply :server:spotlessApply