### PR TITLE
Honor skipped Docker build tasks in precheck

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/docker/DockerSupportPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/docker/DockerSupportPlugin.java
@@ -34,6 +34,7 @@ package org.opensearch.gradle.docker;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.provider.Provider;
 
 import java.io.File;
@@ -62,11 +63,7 @@ public class DockerSupportPlugin implements Plugin<Project> {
 
         // Ensure that if we are trying to run any DockerBuildTask tasks, we assert an available Docker installation exists
         project.getGradle().getTaskGraph().whenReady(graph -> {
-            List<String> dockerTasks = graph.getAllTasks()
-                .stream()
-                .filter(task -> task instanceof DockerBuildTask)
-                .map(Task::getPath)
-                .collect(Collectors.toList());
+            List<String> dockerTasks = runnableDockerTasks(graph.getAllTasks());
 
             if (dockerTasks.isEmpty() == false) {
                 dockerSupportServiceProvider.get().failIfDockerUnavailable(dockerTasks);
@@ -74,4 +71,11 @@ public class DockerSupportPlugin implements Plugin<Project> {
         });
     }
 
+    static List<String> runnableDockerTasks(List<Task> tasks) {
+        return tasks.stream()
+            .filter(task -> task instanceof DockerBuildTask)
+            .filter(task -> ((TaskInternal) task).getOnlyIf().isSatisfiedBy((TaskInternal) task))
+            .map(Task::getPath)
+            .collect(Collectors.toList());
+    }
 }

--- a/buildSrc/src/test/java/org/opensearch/gradle/docker/DockerSupportServiceTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/docker/DockerSupportServiceTests.java
@@ -32,12 +32,18 @@
 package org.opensearch.gradle.docker;
 
 import org.opensearch.gradle.test.GradleIntegrationTestCase;
+import org.gradle.api.Task;
+import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.specs.Spec;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.mockito.Mockito;
+
+import static org.opensearch.gradle.docker.DockerSupportPlugin.runnableDockerTasks;
 import static org.opensearch.gradle.docker.DockerSupportService.deriveId;
 import static org.opensearch.gradle.docker.DockerSupportService.parseOsRelease;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -122,5 +128,23 @@ public class DockerSupportServiceTests extends GradleIntegrationTestCase {
         osRelease.put("VERSION_ID", "6.10");
 
         assertThat("ol-6.10", equalTo(deriveId(osRelease)));
+    }
+
+    public void testRunnableDockerTasksSkipsTasksRejectedByOnlyIf() {
+        DockerBuildTask runnableDockerTask = dockerBuildTask(":distribution:docker:buildDockerImage", task -> true);
+        DockerBuildTask skippedDockerTask = dockerBuildTask(":distribution:docker:buildArm64DockerImage", task -> false);
+        Task nonDockerTask = Mockito.mock(Task.class);
+
+        assertThat(
+            runnableDockerTasks(List.of(runnableDockerTask, skippedDockerTask, nonDockerTask)),
+            equalTo(List.of(runnableDockerTask.getPath()))
+        );
+    }
+
+    private static DockerBuildTask dockerBuildTask(String path, Spec<? super TaskInternal> onlyIf) {
+        DockerBuildTask task = Mockito.mock(DockerBuildTask.class, Mockito.withSettings().extraInterfaces(TaskInternal.class));
+        Mockito.when(task.getPath()).thenReturn(path);
+        Mockito.doReturn(onlyIf).when((TaskInternal) task).getOnlyIf();
+        return task;
     }
 }


### PR DESCRIPTION
## Summary
- Update the Docker availability precheck to ignore DockerBuildTask instances whose onlyIf predicates are not satisfied
- Prevent Windows assemble from failing early on Docker tasks that are already configured to skip on Windows
- Add focused coverage for skipped DockerBuildTask filtering

## Context
The assemble workflow can fail on Windows hosted runners because DockerBuildTask entries are present in the task graph, even though distribution/docker configures those tasks to skip on Windows. The precheck currently fails before Gradle can honor the task onlyIf predicates.

Example failure: https://github.com/opensearch-project/OpenSearch/actions/runs/27112838429/job/80013877306?pr=19680

## Testing
- ./gradlew :build-tools:test --tests org.opensearch.gradle.docker.DockerSupportServiceTests
- ./gradlew :build-tools:spotlessApply