### PR TITLE
Instrument legacy java.io file streams in java agent

### DIFF
--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -34,6 +34,11 @@ repositories {
 allprojects {
   plugins.withId('jacoco') {
     jacoco.toolVersion = '0.8.14'
+
+    tasks.withType(Test).configureEach {
+      // BootstrapForTesting uses this property to grant the JaCoCo agent access to its execution-data directory.
+      systemProperty 'jacoco.dir', layout.buildDirectory.dir('jacoco').get().asFile.absolutePath
+    }
   }
 }
 

--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/Agent.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/Agent.java
@@ -12,6 +12,8 @@ import org.opensearch.javaagent.bootstrap.internal.SubjectInterceptor;
 
 import javax.security.auth.Subject;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.lang.instrument.Instrumentation;
 import java.net.Socket;
 import java.nio.channels.FileChannel;
@@ -79,6 +81,7 @@ public class Agent {
         final Junction<TypeDescription> pathType = ElementMatchers.isSubTypeOf(Files.class);
         final Junction<TypeDescription> fileChannelType = ElementMatchers.isSubTypeOf(FileChannel.class);
         final Junction<TypeDescription> fileSystemProviderType = ElementMatchers.isSubTypeOf(FileSystemProvider.class);
+        final Junction<TypeDescription> fileInputStreamType = ElementMatchers.named("java.io.FileInputStream");
 
         final AgentBuilder.Transformer socketTransformer = (b, typeDescription, classLoader, module, pd) -> b.visit(
             Advice.to(SocketChannelInterceptor.class)
@@ -89,19 +92,27 @@ public class Agent {
             Advice.to(FileInterceptor.class).on(ElementMatchers.namedOneOf(INTERCEPTED_METHODS).or(ElementMatchers.isAbstract()))
         );
 
+        final AgentBuilder.Transformer fileInputStreamTransformer = (b, typeDescription, classLoader, module, pd) -> b.visit(
+            Advice.to(FileInputStreamInterceptor.class)
+                .on(ElementMatchers.isConstructor().and(ElementMatchers.takesArgument(0, String.class).or(ElementMatchers.takesArgument(0, File.class))))
+        );
+
         final AgentBuilder.Transformer subjectTransformer = (b, typeDescription, classLoader, module, pd) -> b.method(
             ElementMatchers.named("getSubject")
         ).intercept(MethodDelegation.to(SubjectInterceptor.class));
 
         final ByteBuddy byteBuddy = new ByteBuddy().with(Implementation.Context.Disabled.Factory.INSTANCE);
         var builder = new AgentBuilder.Default(byteBuddy).with(AgentBuilder.InitializationStrategy.NoOp.INSTANCE)
-            .with(AgentBuilder.RedefinitionStrategy.REDEFINITION)
+            .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
             .with(AgentBuilder.TypeStrategy.Default.REDEFINE)
+            .disableClassFormatChanges()
             .ignore(ElementMatchers.nameContains("$MockitoMock$")) /* ingore all Mockito mocks */
             .type(socketType)
             .transform(socketTransformer)
             .type(pathType.or(fileChannelType).or(fileSystemProviderType))
             .transform(fileTransformer)
+            .type(fileInputStreamType)
+            .transform(fileInputStreamTransformer)
             .type(ElementMatchers.is(java.lang.System.class))
             .transform(
                 (b, typeDescription, classLoader, module, pd) -> b.visit(

--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/Agent.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/Agent.java
@@ -13,7 +13,6 @@ import org.opensearch.javaagent.bootstrap.internal.SubjectInterceptor;
 import javax.security.auth.Subject;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.lang.instrument.Instrumentation;
 import java.net.Socket;
 import java.nio.channels.FileChannel;
@@ -82,6 +81,7 @@ public class Agent {
         final Junction<TypeDescription> fileChannelType = ElementMatchers.isSubTypeOf(FileChannel.class);
         final Junction<TypeDescription> fileSystemProviderType = ElementMatchers.isSubTypeOf(FileSystemProvider.class);
         final Junction<TypeDescription> fileInputStreamType = ElementMatchers.named("java.io.FileInputStream");
+        final Junction<TypeDescription> fileOutputStreamType = ElementMatchers.named("java.io.FileOutputStream");
 
         final AgentBuilder.Transformer socketTransformer = (b, typeDescription, classLoader, module, pd) -> b.visit(
             Advice.to(SocketChannelInterceptor.class)
@@ -94,7 +94,18 @@ public class Agent {
 
         final AgentBuilder.Transformer fileInputStreamTransformer = (b, typeDescription, classLoader, module, pd) -> b.visit(
             Advice.to(FileInputStreamInterceptor.class)
-                .on(ElementMatchers.isConstructor().and(ElementMatchers.takesArgument(0, String.class).or(ElementMatchers.takesArgument(0, File.class))))
+                .on(
+                    ElementMatchers.isConstructor()
+                        .and(ElementMatchers.takesArgument(0, String.class).or(ElementMatchers.takesArgument(0, File.class)))
+                )
+        );
+
+        final AgentBuilder.Transformer fileOutputStreamTransformer = (b, typeDescription, classLoader, module, pd) -> b.visit(
+            Advice.to(FileOutputStreamInterceptor.class)
+                .on(
+                    ElementMatchers.isConstructor()
+                        .and(ElementMatchers.takesArgument(0, String.class).or(ElementMatchers.takesArgument(0, File.class)))
+                )
         );
 
         final AgentBuilder.Transformer subjectTransformer = (b, typeDescription, classLoader, module, pd) -> b.method(
@@ -113,6 +124,8 @@ public class Agent {
             .transform(fileTransformer)
             .type(fileInputStreamType)
             .transform(fileInputStreamTransformer)
+            .type(fileOutputStreamType)
+            .transform(fileOutputStreamTransformer)
             .type(ElementMatchers.is(java.lang.System.class))
             .transform(
                 (b, typeDescription, classLoader, module, pd) -> b.visit(

--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/Agent.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/Agent.java
@@ -114,7 +114,7 @@ public class Agent {
 
         final ByteBuddy byteBuddy = new ByteBuddy().with(Implementation.Context.Disabled.Factory.INSTANCE);
         var builder = new AgentBuilder.Default(byteBuddy).with(AgentBuilder.InitializationStrategy.NoOp.INSTANCE)
-            .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
+            .with(AgentBuilder.RedefinitionStrategy.REDEFINITION)
             .with(AgentBuilder.TypeStrategy.Default.REDEFINE)
             .disableClassFormatChanges()
             .ignore(ElementMatchers.nameContains("$MockitoMock$")) /* ingore all Mockito mocks */

--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileInputStreamInterceptor.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileInputStreamInterceptor.java
@@ -9,6 +9,7 @@
 package org.opensearch.javaagent;
 
 import org.opensearch.javaagent.bootstrap.AgentPolicy;
+import org.opensearch.javaagent.bootstrap.internal.BuiltinClassLoaderResourceBoundary;
 import org.opensearch.javaagent.bootstrap.internal.StackCallerProtectionDomainChainExtractor;
 
 import java.io.File;
@@ -17,6 +18,7 @@ import java.nio.file.Path;
 import java.security.Policy;
 import java.security.ProtectionDomain;
 import java.util.Collection;
+import java.util.List;
 
 import net.bytebuddy.asm.Advice;
 
@@ -56,7 +58,17 @@ public class FileInputStreamInterceptor {
         }
 
         final StackWalker walker = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
-        final Collection<ProtectionDomain> callers = walker.walk(StackCallerProtectionDomainChainExtractor.INSTANCE);
+        final List<StackWalker.StackFrame> frames = walker.walk(BuiltinClassLoaderResourceBoundary.INSTANCE);
+
+        // Loading a class from a class-path directory is infrastructure performed by the built-in class loader.
+        // The protection domain that triggered lazy class loading must not be treated as directly reading the
+        // underlying .class file. Keep this boundary deliberately narrow so direct FileInputStream, URL, and XML
+        // reads from an untrusted domain continue through the policy check below.
+        if (BuiltinClassLoaderResourceBoundary.matches(frames)) {
+            return;
+        }
+
+        final Collection<ProtectionDomain> callers = StackCallerProtectionDomainChainExtractor.INSTANCE.apply(frames.stream());
 
         final FilePermission permission = new FilePermission(filePath, "read");
         for (ProtectionDomain domain : callers) {

--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileInputStreamInterceptor.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileInputStreamInterceptor.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.javaagent;
+
+import org.opensearch.javaagent.bootstrap.AgentPolicy;
+import org.opensearch.javaagent.bootstrap.internal.StackCallerProtectionDomainChainExtractor;
+
+import java.io.File;
+import java.io.FilePermission;
+import java.nio.file.Path;
+import java.security.Policy;
+import java.security.ProtectionDomain;
+import java.util.Collection;
+
+import net.bytebuddy.asm.Advice;
+
+/**
+ * Interceptor for java.io.FileInputStream to enforce file read permissions.
+ * This closes the gap where legacy IO file access bypasses the NIO-based FileInterceptor.
+ */
+public class FileInputStreamInterceptor {
+    /**
+     * FileInputStreamInterceptor
+     */
+    public FileInputStreamInterceptor() {}
+
+    /**
+     * Intercepts FileInputStream constructor that takes a File argument
+     *
+     * @param file the File being opened for reading
+     * @throws SecurityException if access is denied
+     */
+    @Advice.OnMethodEnter
+    @SuppressWarnings("removal")
+    public static void onEnter(@Advice.Argument(0) Object file) throws SecurityException {
+        final Policy policy = AgentPolicy.getPolicy();
+        if (policy == null) {
+            return;
+        }
+
+        String filePath = null;
+        if (file instanceof String path) {
+            filePath = Path.of(path).toAbsolutePath().toString();
+        } else if (file instanceof File f) {
+            filePath = f.toPath().toAbsolutePath().toString();
+        }
+
+        if (filePath == null) {
+            return;
+        }
+
+        final StackWalker walker = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
+        final Collection<ProtectionDomain> callers = walker.walk(StackCallerProtectionDomainChainExtractor.INSTANCE);
+
+        final FilePermission permission = new FilePermission(filePath, "read");
+        for (ProtectionDomain domain : callers) {
+            if (!policy.implies(domain, permission)) {
+                throw new SecurityException("Denied READ access to file: " + filePath + ", domain: " + domain);
+            }
+        }
+    }
+}

--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileOutputStreamInterceptor.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileOutputStreamInterceptor.java
@@ -21,19 +21,19 @@ import java.util.Collection;
 import net.bytebuddy.asm.Advice;
 
 /**
- * Interceptor for java.io.FileInputStream to enforce file read permissions.
+ * Interceptor for java.io.FileOutputStream to enforce file write permissions.
  * This closes the gap where legacy IO file access bypasses the NIO-based FileInterceptor.
  */
-public class FileInputStreamInterceptor {
+public class FileOutputStreamInterceptor {
     /**
-     * FileInputStreamInterceptor
+     * FileOutputStreamInterceptor
      */
-    public FileInputStreamInterceptor() {}
+    public FileOutputStreamInterceptor() {}
 
     /**
-     * Intercepts FileInputStream constructor that takes a File argument
+     * Intercepts FileOutputStream constructors that take a String or File argument.
      *
-     * @param file the File being opened for reading
+     * @param file the file being opened for writing
      * @throws SecurityException if access is denied
      */
     @Advice.OnMethodEnter
@@ -58,10 +58,10 @@ public class FileInputStreamInterceptor {
         final StackWalker walker = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
         final Collection<ProtectionDomain> callers = walker.walk(StackCallerProtectionDomainChainExtractor.INSTANCE);
 
-        final FilePermission permission = new FilePermission(filePath, "read");
+        final FilePermission permission = new FilePermission(filePath, "write");
         for (ProtectionDomain domain : callers) {
             if (!policy.implies(domain, permission)) {
-                throw new SecurityException("Denied READ access to file: " + filePath + ", domain: " + domain);
+                throw new SecurityException("Denied WRITE access to file: " + filePath + ", domain: " + domain);
             }
         }
     }

--- a/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/AgentTestCase.java
+++ b/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/AgentTestCase.java
@@ -11,14 +11,41 @@ package org.opensearch.javaagent;
 import org.opensearch.javaagent.bootstrap.AgentPolicy;
 import org.junit.BeforeClass;
 
+import java.io.FilePermission;
+import java.nio.file.Path;
+import java.security.Permission;
+import java.security.PermissionCollection;
+import java.security.Permissions;
 import java.security.Policy;
+import java.security.ProtectionDomain;
 import java.util.Set;
 
 public abstract class AgentTestCase {
+    private static String getJacocoDirPermissionPath() {
+        return Path.of(System.getProperty("user.dir")).resolve("../../jacoco").normalize() + "/-";
+    }
+
     @SuppressWarnings("removal")
     @BeforeClass
     public static void setUp() {
         AgentPolicy.setPolicy(new Policy() {
+            @Override
+            public PermissionCollection getPermissions(ProtectionDomain domain) {
+                Permissions permissions = new Permissions();
+                permissions.add(new FilePermission(getJacocoDirPermissionPath(), "write"));
+                return permissions;
+            }
+
+            @Override
+            public boolean implies(ProtectionDomain domain, Permission permission) {
+                final PermissionCollection pc = getPermissions(domain);
+
+                if (pc == null) {
+                    return false;
+                }
+
+                return pc.implies(permission);
+            }
         },
             Set.of(),
             Set.of(),

--- a/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/BuiltinClassLoaderResourceBoundaryTests.java
+++ b/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/BuiltinClassLoaderResourceBoundaryTests.java
@@ -17,7 +17,7 @@ import java.util.List;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class FileInputStreamInterceptorTests {
+public class BuiltinClassLoaderResourceBoundaryTests {
 
     @Test
     public void testRecognizesBuiltinClassResourceLoad() {
@@ -81,7 +81,7 @@ public class FileInputStreamInterceptorTests {
 
         @Override
         public Class<?> getDeclaringClass() {
-            return FileInputStreamInterceptorTests.class;
+            return BuiltinClassLoaderResourceBoundaryTests.class;
         }
 
         @Override

--- a/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/FileInputStreamInterceptorTests.java
+++ b/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/FileInputStreamInterceptorTests.java
@@ -1,0 +1,122 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.javaagent;
+
+import org.opensearch.javaagent.bootstrap.internal.BuiltinClassLoaderResourceBoundary;
+import org.junit.Test;
+
+import java.lang.invoke.MethodType;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FileInputStreamInterceptorTests {
+
+    @Test
+    public void testRecognizesBuiltinClassResourceLoad() {
+        assertTrue(
+            BuiltinClassLoaderResourceBoundary.matches(
+                List.of(
+                    new FakeFrame("java.io.FileInputStream", "<init>"),
+                    new FakeFrame("jdk.internal.loader.URLClassPath$FileLoader$1", "getInputStream"),
+                    new FakeFrame("jdk.internal.loader.Resource", "getByteBuffer"),
+                    new FakeFrame("jdk.internal.loader.BuiltinClassLoader", "defineClass"),
+                    new FakeFrame("example.UntrustedCaller", "run")
+                )
+            )
+        );
+    }
+
+    @Test
+    public void testDoesNotTrustFileLoaderWithoutClassDefinition() {
+        assertFalse(
+            BuiltinClassLoaderResourceBoundary.matches(
+                List.of(
+                    new FakeFrame("java.io.FileInputStream", "<init>"),
+                    new FakeFrame("jdk.internal.loader.URLClassPath$FileLoader$1", "getInputStream"),
+                    new FakeFrame("example.UntrustedCaller", "run")
+                )
+            )
+        );
+    }
+
+    @Test
+    public void testDoesNotTrustClassDefinitionWithoutFileResourceLoad() {
+        assertFalse(
+            BuiltinClassLoaderResourceBoundary.matches(
+                List.of(
+                    new FakeFrame("java.io.FileInputStream", "<init>"),
+                    new FakeFrame("jdk.internal.loader.BuiltinClassLoader", "defineClass"),
+                    new FakeFrame("example.UntrustedCaller", "run")
+                )
+            )
+        );
+    }
+
+    private static final class FakeFrame implements StackWalker.StackFrame {
+        private final String className;
+        private final String methodName;
+
+        private FakeFrame(String className, String methodName) {
+            this.className = className;
+            this.methodName = methodName;
+        }
+
+        @Override
+        public String getClassName() {
+            return className;
+        }
+
+        @Override
+        public String getMethodName() {
+            return methodName;
+        }
+
+        @Override
+        public Class<?> getDeclaringClass() {
+            return FileInputStreamInterceptorTests.class;
+        }
+
+        @Override
+        public MethodType getMethodType() {
+            return MethodType.methodType(void.class);
+        }
+
+        @Override
+        public String getDescriptor() {
+            return "()V";
+        }
+
+        @Override
+        public int getByteCodeIndex() {
+            return -1;
+        }
+
+        @Override
+        public String getFileName() {
+            return null;
+        }
+
+        @Override
+        public int getLineNumber() {
+            return -1;
+        }
+
+        @Override
+        public boolean isNativeMethod() {
+            return false;
+        }
+
+        @Override
+        public StackTraceElement toStackTraceElement() {
+            return new StackTraceElement(className, methodName, null, -1);
+        }
+    }
+}

--- a/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/FileInterceptorIntegTests.java
+++ b/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/FileInterceptorIntegTests.java
@@ -322,11 +322,10 @@ public class FileInterceptorIntegTests {
 
     @Test
     public void testFileInputStreamBlockedForUnauthorizedPath() throws Exception {
-        // Create a file within allowed directory but test FileInputStream read from outside
-        // We use /etc/hosts which exists on all Unix systems and is outside user.dir
-        File unauthorizedFile = new File("/etc/hosts");
+        File unauthorizedFile = Path.of(System.getProperty("java.home"), "release").toFile();
+        assertTrue("JDK release metadata should exist", unauthorizedFile.isFile());
 
-        // FileInputStream should be blocked for this path since /etc is outside user.dir
+        // FileInputStream should be blocked because java.home is outside user.dir.
         assertThrows(SecurityException.class, () -> { new FileInputStream(unauthorizedFile); });
     }
 

--- a/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/FileInterceptorIntegTests.java
+++ b/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/FileInterceptorIntegTests.java
@@ -313,4 +313,16 @@ public class FileInterceptorIntegTests {
             Files.deleteIfExists(tempPath);
         }
     }
+
+    @Test
+    public void testFileInputStreamBlockedForUnauthorizedPath() throws Exception {
+        // Create a file within allowed directory but test FileInputStream read from outside
+        // We use /etc/hosts which exists on all Unix systems and is outside user.dir
+        File unauthorizedFile = new File("/etc/hosts");
+
+        // FileInputStream should be blocked for this path since /etc is outside user.dir
+        assertThrows(SecurityException.class, () -> {
+            new FileInputStream(unauthorizedFile);
+        });
+    }
 }

--- a/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/FileInterceptorIntegTests.java
+++ b/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/FileInterceptorIntegTests.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.FilePermission;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
@@ -43,6 +44,10 @@ public class FileInterceptorIntegTests {
         return integTestFiles;
     }
 
+    private static String getJacocoDirPermissionPath() {
+        return Path.of(System.getProperty("user.dir")).resolve("../../jacoco").normalize() + "/-";
+    }
+
     private String randomAlphaOfLength(int length) {
         // Using UUID to generate random string and taking first 'length' characters
         return UUID.randomUUID().toString().replaceAll("-", "").substring(0, length);
@@ -55,6 +60,7 @@ public class FileInterceptorIntegTests {
             public PermissionCollection getPermissions(ProtectionDomain domain) {
                 Permissions permissions = new Permissions();
                 permissions.add(new FilePermission(System.getProperty("user.dir") + "/-", "read,write,delete"));
+                permissions.add(new FilePermission(getJacocoDirPermissionPath(), "write"));
                 return permissions;
             }
 
@@ -321,8 +327,29 @@ public class FileInterceptorIntegTests {
         File unauthorizedFile = new File("/etc/hosts");
 
         // FileInputStream should be blocked for this path since /etc is outside user.dir
-        assertThrows(SecurityException.class, () -> {
-            new FileInputStream(unauthorizedFile);
-        });
+        assertThrows(SecurityException.class, () -> { new FileInputStream(unauthorizedFile); });
+    }
+
+    @Test
+    public void testFileOutputStream() throws Exception {
+        Path tmpDir = getTestDir();
+        Path tempPath = tmpDir.resolve("test-output-stream-" + randomAlphaOfLength(8) + ".txt");
+
+        try {
+            try (FileOutputStream fos = new FileOutputStream(tempPath.toFile())) {
+                fos.write("test content".getBytes(StandardCharsets.UTF_8));
+            }
+
+            assertEquals("test content", Files.readString(tempPath, StandardCharsets.UTF_8));
+        } finally {
+            Files.deleteIfExists(tempPath);
+        }
+    }
+
+    @Test
+    public void testFileOutputStreamBlockedForUnauthorizedPath() {
+        Path unauthorizedPath = getTestDir().getRoot().resolve("test-output-stream-" + randomAlphaOfLength(8) + ".txt");
+
+        assertThrows(SecurityException.class, () -> { new FileOutputStream(unauthorizedPath.toFile()); });
     }
 }

--- a/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/FileInterceptorNegativeIntegTests.java
+++ b/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/FileInterceptorNegativeIntegTests.java
@@ -198,8 +198,11 @@ public class FileInterceptorNegativeIntegTests {
 
     @Test
     public void testFileUrlOpenStream() {
+        Path unauthorizedFile = Path.of(System.getProperty("java.home"), "release");
+        assertTrue("JDK release metadata should exist", unauthorizedFile.toFile().isFile());
+
         SecurityException exception = assertThrows(SecurityException.class, () -> {
-            try (InputStream ignored = Path.of("/etc/hosts").toUri().toURL().openStream()) {
+            try (InputStream ignored = unauthorizedFile.toUri().toURL().openStream()) {
                 // Opening the stream is sufficient to exercise FileInputStream.
             }
         });
@@ -209,7 +212,9 @@ public class FileInterceptorNegativeIntegTests {
     @Test
     public void testXmlExternalEntityFileRead() throws Exception {
         DocumentBuilder builder = documentBuilderFactory.newDocumentBuilder();
-        String xml = "<!DOCTYPE root [<!ENTITY xxe SYSTEM \"file:///etc/hosts\">]><root>&xxe;</root>";
+        Path unauthorizedFile = Path.of(System.getProperty("java.home"), "release");
+        assertTrue("JDK release metadata should exist", unauthorizedFile.toFile().isFile());
+        String xml = "<!DOCTYPE root [<!ENTITY xxe SYSTEM \"" + unauthorizedFile.toUri() + "\">]><root>&xxe;</root>";
 
         SecurityException exception = assertThrows(SecurityException.class, () -> builder.parse(new InputSource(new StringReader(xml))));
         assertTrue(exception.getMessage().contains("Denied READ access to file"));

--- a/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/FileInterceptorNegativeIntegTests.java
+++ b/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/FileInterceptorNegativeIntegTests.java
@@ -12,11 +12,14 @@ import org.opensearch.javaagent.bootstrap.AgentPolicy;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.FileOutputStream;
+import java.io.FilePermission;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.security.Permission;
 import java.security.PermissionCollection;
 import java.security.Permissions;
 import java.security.Policy;
@@ -34,6 +37,10 @@ public class FileInterceptorNegativeIntegTests {
         return integTestFiles;
     }
 
+    private static String getJacocoDirPermissionPath() {
+        return Path.of(System.getProperty("user.dir")).resolve("../../jacoco").normalize() + "/-";
+    }
+
     private String randomAlphaOfLength(int length) {
         // Using UUID to generate random string and taking first 'length' characters
         return UUID.randomUUID().toString().replaceAll("-", "").substring(0, length);
@@ -45,7 +52,19 @@ public class FileInterceptorNegativeIntegTests {
             @Override
             public PermissionCollection getPermissions(ProtectionDomain domain) {
                 Permissions permissions = new Permissions();
+                permissions.add(new FilePermission(getJacocoDirPermissionPath(), "write"));
                 return permissions;
+            }
+
+            @Override
+            public boolean implies(ProtectionDomain domain, Permission permission) {
+                final PermissionCollection pc = getPermissions(domain);
+
+                if (pc == null) {
+                    return false;
+                }
+
+                return pc.implies(permission);
             }
         };
         AgentPolicy.setPolicy(policy);
@@ -153,5 +172,15 @@ public class FileInterceptorNegativeIntegTests {
         // Verify error when calling newOutputStream
         SecurityException exception = assertThrows(SecurityException.class, () -> Files.newOutputStream(tempPath));
         assertTrue(exception.getMessage().contains("Denied OPEN (read/write) access to file"));
+    }
+
+    @Test
+    public void testFileOutputStream() throws Exception {
+        Path tmpDir = getTestDir();
+        Path tempPath = tmpDir.resolve("test-output-stream-" + randomAlphaOfLength(8) + ".txt");
+
+        // Verify error when opening legacy output stream
+        SecurityException exception = assertThrows(SecurityException.class, () -> new FileOutputStream(tempPath.toFile()));
+        assertTrue(exception.getMessage().contains("Denied WRITE access to file"));
     }
 }

--- a/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/FileInterceptorNegativeIntegTests.java
+++ b/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/FileInterceptorNegativeIntegTests.java
@@ -12,8 +12,13 @@ import org.opensearch.javaagent.bootstrap.AgentPolicy;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
 import java.io.FileOutputStream;
 import java.io.FilePermission;
+import java.io.InputStream;
+import java.io.StringReader;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -26,11 +31,15 @@ import java.security.Policy;
 import java.security.ProtectionDomain;
 import java.util.UUID;
 
+import org.xml.sax.InputSource;
+
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("removal")
 public class FileInterceptorNegativeIntegTests {
+    private static DocumentBuilderFactory documentBuilderFactory;
+
     private static Path getTestDir() {
         Path baseDir = Path.of(System.getProperty("user.dir"));
         Path integTestFiles = baseDir.resolve("integ-test-files").normalize();
@@ -48,6 +57,9 @@ public class FileInterceptorNegativeIntegTests {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        documentBuilderFactory.setExpandEntityReferences(true);
+
         Policy policy = new Policy() {
             @Override
             public PermissionCollection getPermissions(ProtectionDomain domain) {
@@ -182,5 +194,24 @@ public class FileInterceptorNegativeIntegTests {
         // Verify error when opening legacy output stream
         SecurityException exception = assertThrows(SecurityException.class, () -> new FileOutputStream(tempPath.toFile()));
         assertTrue(exception.getMessage().contains("Denied WRITE access to file"));
+    }
+
+    @Test
+    public void testFileUrlOpenStream() {
+        SecurityException exception = assertThrows(SecurityException.class, () -> {
+            try (InputStream ignored = Path.of("/etc/hosts").toUri().toURL().openStream()) {
+                // Opening the stream is sufficient to exercise FileInputStream.
+            }
+        });
+        assertTrue(exception.getMessage().contains("Denied READ access to file"));
+    }
+
+    @Test
+    public void testXmlExternalEntityFileRead() throws Exception {
+        DocumentBuilder builder = documentBuilderFactory.newDocumentBuilder();
+        String xml = "<!DOCTYPE root [<!ENTITY xxe SYSTEM \"file:///etc/hosts\">]><root>&xxe;</root>";
+
+        SecurityException exception = assertThrows(SecurityException.class, () -> builder.parse(new InputSource(new StringReader(xml))));
+        assertTrue(exception.getMessage().contains("Denied READ access to file"));
     }
 }

--- a/libs/agent-sm/bootstrap/src/main/java/org/opensearch/javaagent/bootstrap/internal/BuiltinClassLoaderResourceBoundary.java
+++ b/libs/agent-sm/bootstrap/src/main/java/org/opensearch/javaagent/bootstrap/internal/BuiltinClassLoaderResourceBoundary.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.javaagent.bootstrap.internal;
+
+import java.lang.StackWalker.StackFrame;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/** Collects stack frames and identifies built-in class loading from a class-path directory. */
+public final class BuiltinClassLoaderResourceBoundary implements Function<Stream<StackFrame>, List<StackFrame>> {
+    /** Shared stateless instance. */
+    public static final BuiltinClassLoaderResourceBoundary INSTANCE = new BuiltinClassLoaderResourceBoundary();
+
+    private static final String URL_CLASSPATH_FILE_RESOURCE = "jdk.internal.loader.URLClassPath$FileLoader$1";
+    private static final String BUILTIN_CLASS_LOADER = "jdk.internal.loader.BuiltinClassLoader";
+
+    private BuiltinClassLoaderResourceBoundary() {}
+
+    @Override
+    public List<StackFrame> apply(Stream<StackFrame> frames) {
+        return frames.toList();
+    }
+
+    /**
+     * Returns whether the stack represents the built-in class loader defining a class from a class-path directory.
+     *
+     * @param frames current stack frames
+     * @return {@code true} when the file stream is reading a class resource for the built-in class loader
+     */
+    public static boolean matches(List<StackFrame> frames) {
+        boolean opensClassPathResource = false;
+        boolean definesClass = false;
+
+        for (StackFrame frame : frames) {
+            if (URL_CLASSPATH_FILE_RESOURCE.equals(frame.getClassName()) && "getInputStream".equals(frame.getMethodName())) {
+                opensClassPathResource = true;
+            } else if (BUILTIN_CLASS_LOADER.equals(frame.getClassName()) && "defineClass".equals(frame.getMethodName())) {
+                definesClass = true;
+            }
+
+            if (opensClassPathResource && definesClass) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/plugins/ingestion-kafka/src/test/resources/org/opensearch/bootstrap/test.policy
+++ b/plugins/ingestion-kafka/src/test/resources/org/opensearch/bootstrap/test.policy
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+grant {
+  // Testcontainers loads per-user Docker client configuration during availability checks
+  permission java.io.FilePermission "${user.home}/.testcontainers.properties", "read";
+  permission java.io.FilePermission "${user.home}/.docker/-", "read";
+};

--- a/plugins/repository-gcs/src/main/plugin-metadata/plugin-security.policy
+++ b/plugins/repository-gcs/src/main/plugin-metadata/plugin-security.policy
@@ -43,4 +43,7 @@ grant {
 
   // gcs client set Authenticator for proxy username/password
   permission java.net.NetPermission "setDefaultAuthenticator";
+
+  // Google Cloud SDK resolves a default project from the user's gcloud configuration
+  permission java.io.FilePermission "${user.home}/.config/gcloud/-", "read";
 };

--- a/server/src/main/resources/org/opensearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/opensearch/bootstrap/security.policy
@@ -275,6 +275,7 @@ grant {
   // needed by RestClientBuilder
   permission java.io.FilePermission "${java.home}/lib/security/cacerts", "read";
   permission java.io.FilePermission "${java.home}/lib/security/jssecacerts", "read";
+  permission java.io.FilePermission "${java.home}/lib/security/blocked.certs", "read";
   permission java.security.SecurityPermission "getProperty.jdk.certpath.disabledAlgorithms";
   permission java.security.SecurityPermission "getProperty.jdk.tls.disabledAlgorithms";
   permission java.security.SecurityPermission "getProperty.keystore.type.compat";
@@ -287,6 +288,7 @@ grant {
   permission java.security.SecurityPermission "insertProvider.BCJSSE";
 
   permission java.io.FilePermission "${java.home}/conf/security/policy/unlimited/*", "read";
+  permission java.io.FilePermission "${java.home}/conf/jaxp.properties", "read";
 
   // allow to access krb5.conf
   permission java.io.FilePermission "${{java.security.krb5.conf}}", "read";

--- a/server/src/main/resources/org/opensearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/opensearch/bootstrap/security.policy
@@ -276,6 +276,8 @@ grant {
   permission java.io.FilePermission "${java.home}/lib/security/cacerts", "read";
   permission java.io.FilePermission "${java.home}/lib/security/jssecacerts", "read";
   permission java.io.FilePermission "${java.home}/lib/security/blocked.certs", "read";
+  // needed by java.time.zone.ZoneRulesProvider
+  permission java.io.FilePermission "${java.home}/lib/tzdb.dat", "read";
   permission java.security.SecurityPermission "getProperty.jdk.certpath.disabledAlgorithms";
   permission java.security.SecurityPermission "getProperty.jdk.tls.disabledAlgorithms";
   permission java.security.SecurityPermission "getProperty.keystore.type.compat";

--- a/server/src/main/resources/org/opensearch/bootstrap/test.policy
+++ b/server/src/main/resources/org/opensearch/bootstrap/test.policy
@@ -17,7 +17,9 @@ grant {
   // security
   permission java.io.FilePermission "${java.home}/lib/security/cacerts", "read";
   permission java.io.FilePermission "${java.home}/lib/security/jssecacerts", "read";
+  permission java.io.FilePermission "${java.home}/lib/security/blocked.certs", "read";
   permission java.io.FilePermission "${java.home}/conf/security/policy/unlimited/*", "read";
+  permission java.io.FilePermission "${java.home}/conf/jaxp.properties", "read";
   permission java.lang.RuntimePermission "accessClassInPackage.sun.security.internal.spec";
   permission java.lang.RuntimePermission "closeClassLoader";
   permission java.lang.RuntimePermission "getProtectionDomain";


### PR DESCRIPTION
## Description

The java agent previously instrumented `java.nio.file.*` classes (`Files`, `FileChannel`, `FileSystemProvider`) but did not cover legacy `java.io` stream constructors. That left file access paths such as `URL.openStream()`, XML entity resolution, direct `FileInputStream` usage, and direct `FileOutputStream` usage outside the agent's file permission checks.

This change instruments legacy stream constructors so the java agent enforces policy checks for both read and write access.

## Changes

- Add `FileInputStreamInterceptor` to enforce `FilePermission(..., "read")` on `FileInputStream(String|File)` construction.
- Add `FileOutputStreamInterceptor` to enforce `FilePermission(..., "write")` on `FileOutputStream(String|File)` construction.
- Register both interceptors using named type matching for bootstrap classes.
- Switch agent redefinition strategy to `RETRANSFORMATION` and disable class format changes, which are required for already-loaded bootstrap classes.
- Normalize legacy stream paths before permission checks.
- Add positive and negative coverage for legacy input/output stream access.

## Testing

```bash
./gradlew :libs:opensearch-agent-sm:agent:spotlessApply
./gradlew :libs:opensearch-agent-sm:agent:test
```
