### PR TITLE
Add dynamic file permission enforcement toggle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -431,6 +431,7 @@ gradle.projectsEvaluated {
         if (!(project.path in [':build-tools', ":libs:agent-sm:bootstrap", ":libs:agent-sm:agent"])) {
           dependsOn(project(':libs:agent-sm:agent').tasks.named('prepareAgent'))
           jvmArgs += ["-javaagent:" + project(':libs:agent-sm:agent').tasks.named('jar').get().archiveFile.get()]
+          systemProperty 'jacoco.dir', project.layout.buildDirectory.dir('jacoco').get().asFile.absolutePath
         }
         if (BuildParams.isInFipsJvm()) {
           def fipsSecurityFile = project.rootProject.file('distribution/src/config/fips_java.security')
@@ -734,4 +735,3 @@ tasks.withType(TestTaskReports).configureEach {
 tasks.named(JavaBasePlugin.CHECK_TASK_NAME) {
   dependsOn tasks.named('testAggregateTestReport', TestReport)
 }
-

--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileInputStreamInterceptor.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileInputStreamInterceptor.java
@@ -59,6 +59,10 @@ public class FileInputStreamInterceptor {
         final Collection<ProtectionDomain> callers = walker.walk(StackCallerProtectionDomainChainExtractor.INSTANCE);
 
         final FilePermission permission = new FilePermission(filePath, "read");
+        if (AgentPolicy.shouldEnforce(permission) == false) {
+            return;
+        }
+
         for (ProtectionDomain domain : callers) {
             if (!policy.implies(domain, permission)) {
                 throw new SecurityException("Denied READ access to file: " + filePath + ", domain: " + domain);

--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileInterceptor.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileInterceptor.java
@@ -144,33 +144,47 @@ public class FileInterceptor {
             for (final ProtectionDomain domain : callers) {
                 // Handle FileChannel.open() separately to check read/write permissions properly
                 if (method.getName().equals("open") || method.getName().equals("newByteChannel")) {
-                    if (isMutating == true && !policy.implies(domain, new FilePermission(filePath, "read,write"))) {
+                    final FilePermission permission = new FilePermission(filePath, isMutating ? "read,write" : "read");
+                    if (AgentPolicy.shouldEnforce(permission) == false) {
+                        return;
+                    }
+                    if (isMutating == true && !policy.implies(domain, permission)) {
                         throw new SecurityException("Denied OPEN (read/write) access to file: " + filePath + ", domain: " + domain);
-                    } else if (!policy.implies(domain, new FilePermission(filePath, "read"))) {
+                    } else if (!policy.implies(domain, permission)) {
                         throw new SecurityException("Denied OPEN (read) access to file: " + filePath + ", domain: " + domain);
                     }
                 }
 
                 // Handle Files.copy() separately to check read/write permissions properly
                 if (method.getName().equals("copy")) {
-                    if (!policy.implies(domain, new FilePermission(filePath, "read"))) {
+                    final FilePermission readPermission = new FilePermission(filePath, "read");
+                    if (AgentPolicy.shouldEnforce(readPermission) == false) {
+                        return;
+                    }
+                    if (!policy.implies(domain, readPermission)) {
                         throw new SecurityException("Denied COPY (read) access to file: " + filePath + ", domain: " + domain);
                     }
 
                     if (targetFilePath != null) {
-                        if (!policy.implies(domain, new FilePermission(targetFilePath, "write"))) {
+                        final FilePermission writePermission = new FilePermission(targetFilePath, "write");
+                        if (AgentPolicy.shouldEnforce(writePermission) == false) {
+                            return;
+                        }
+                        if (!policy.implies(domain, writePermission)) {
                             throw new SecurityException("Denied COPY (write) access to file: " + targetFilePath + ", domain: " + domain);
                         }
                     }
                 }
 
                 // File mutating operations
-                if (isMutating && !policy.implies(domain, new FilePermission(filePath, "write"))) {
+                final FilePermission writePermission = new FilePermission(filePath, "write");
+                if (isMutating && AgentPolicy.shouldEnforce(writePermission) && !policy.implies(domain, writePermission)) {
                     throw new SecurityException("Denied WRITE access to file: " + filePath + ", domain: " + domain);
                 }
 
                 // File deletion operations
-                if (isDelete && !policy.implies(domain, new FilePermission(filePath, "delete"))) {
+                final FilePermission deletePermission = new FilePermission(filePath, "delete");
+                if (isDelete && AgentPolicy.shouldEnforce(deletePermission) && !policy.implies(domain, deletePermission)) {
                     throw new SecurityException("Denied DELETE access to file: " + filePath + ", domain: " + domain);
                 }
             }

--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileOutputStreamInterceptor.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileOutputStreamInterceptor.java
@@ -59,6 +59,10 @@ public class FileOutputStreamInterceptor {
         final Collection<ProtectionDomain> callers = walker.walk(StackCallerProtectionDomainChainExtractor.INSTANCE);
 
         final FilePermission permission = new FilePermission(filePath, "write");
+        if (AgentPolicy.shouldEnforce(permission) == false) {
+            return;
+        }
+
         for (ProtectionDomain domain : callers) {
             if (!policy.implies(domain, permission)) {
                 throw new SecurityException("Denied WRITE access to file: " + filePath + ", domain: " + domain);

--- a/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/FileInterceptorIntegTests.java
+++ b/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/FileInterceptorIntegTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.javaagent;
 
 import org.opensearch.javaagent.bootstrap.AgentPolicy;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -38,6 +39,8 @@ import static org.junit.Assert.assertTrue;
 @SuppressWarnings("removal")
 public class FileInterceptorIntegTests {
 
+    private static Path externalTestDir;
+
     private static Path getTestDir() {
         Path baseDir = Path.of(System.getProperty("user.dir"));
         Path integTestFiles = baseDir.resolve("integ-test-files").normalize();
@@ -55,6 +58,8 @@ public class FileInterceptorIntegTests {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        Path baseDir = Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize();
+        externalTestDir = Files.createTempDirectory(baseDir.getParent(), "agent-permission-toggle");
         Policy policy = new Policy() {
             @Override
             public PermissionCollection getPermissions(ProtectionDomain domain) {
@@ -77,6 +82,27 @@ public class FileInterceptorIntegTests {
         };
         AgentPolicy.setPolicy(policy);
         Files.createDirectories(getTestDir());
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        AgentPolicy.setFilePermissionEnforcementEnabled(false);
+        try {
+            if (externalTestDir != null) {
+                try (var files = Files.list(externalTestDir)) {
+                    files.forEach(path -> {
+                        try {
+                            Files.deleteIfExists(path);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+                }
+                Files.deleteIfExists(externalTestDir);
+            }
+        } finally {
+            AgentPolicy.setFilePermissionEnforcementEnabled(true);
+        }
     }
 
     @Test
@@ -351,5 +377,31 @@ public class FileInterceptorIntegTests {
         Path unauthorizedPath = getTestDir().getRoot().resolve("test-output-stream-" + randomAlphaOfLength(8) + ".txt");
 
         assertThrows(SecurityException.class, () -> { new FileOutputStream(unauthorizedPath.toFile()); });
+    }
+
+    @Test
+    public void testFilePermissionEnforcementCanBeDisabled() throws Exception {
+        Path unauthorizedPath = externalTestDir.resolve("test-output-stream-" + randomAlphaOfLength(8) + ".txt");
+
+        assertThrows(SecurityException.class, () -> { new FileOutputStream(unauthorizedPath.toFile()); });
+
+        AgentPolicy.setFilePermissionEnforcementEnabled(false);
+        try {
+            try (FileOutputStream fos = new FileOutputStream(unauthorizedPath.toFile())) {
+                fos.write("test content".getBytes(StandardCharsets.UTF_8));
+            }
+            assertEquals("test content", Files.readString(unauthorizedPath, StandardCharsets.UTF_8));
+        } finally {
+            AgentPolicy.setFilePermissionEnforcementEnabled(true);
+        }
+
+        assertThrows(SecurityException.class, () -> { new FileOutputStream(unauthorizedPath.toFile()); });
+
+        AgentPolicy.setFilePermissionEnforcementEnabled(false);
+        try {
+            Files.deleteIfExists(unauthorizedPath);
+        } finally {
+            AgentPolicy.setFilePermissionEnforcementEnabled(true);
+        }
     }
 }

--- a/libs/agent-sm/bootstrap/src/main/java/org/opensearch/javaagent/bootstrap/AgentPolicy.java
+++ b/libs/agent-sm/bootstrap/src/main/java/org/opensearch/javaagent/bootstrap/AgentPolicy.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.javaagent.bootstrap;
 
+import java.io.FilePermission;
 import java.lang.StackWalker.Option;
 import java.lang.StackWalker.StackFrame;
 import java.security.Permission;
@@ -30,6 +31,7 @@ public class AgentPolicy {
     private static volatile Set<String> trustedHosts;
     private static volatile Set<String> trustedFileSystems;
     private static volatile BiFunction<Class<?>, Collection<Class<?>>, Boolean> classesThatCanExit;
+    private static volatile boolean filePermissionEnforcementEnabled = true;
 
     /**
      * None of the classes is allowed to call {@link System#exit} or {@link Runtime#halt}
@@ -172,6 +174,23 @@ public class AgentPolicy {
      */
     public static Policy getPolicy() {
         return policy;
+    }
+
+    /**
+     * Set whether file permissions are enforced by the agent.
+     * @param enabled true if file permissions should be enforced
+     */
+    public static void setFilePermissionEnforcementEnabled(boolean enabled) {
+        filePermissionEnforcementEnabled = enabled;
+    }
+
+    /**
+     * Check if the agent should enforce the given permission.
+     * @param permission permission
+     * @return true if permission should be enforced
+     */
+    public static boolean shouldEnforce(Permission permission) {
+        return permission instanceof FilePermission == false || filePermissionEnforcementEnabled;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/bootstrap/BootstrapSettings.java
+++ b/server/src/main/java/org/opensearch/bootstrap/BootstrapSettings.java
@@ -54,6 +54,14 @@ public final class BootstrapSettings {
         Property.NodeScope
     );
 
+    public static final Setting<Boolean> AGENT_FILE_PERMISSION_ENFORCEMENT_ENABLED = Setting.boolSetting(
+        "plugins.security.agent.enforce_file_permissions",
+        true,
+        Property.Dynamic,
+        Property.NodeScope,
+        Property.Sensitive
+    );
+
     public static final Setting<Boolean> MEMORY_LOCK_SETTING = Setting.boolSetting("bootstrap.memory_lock", false, Property.NodeScope);
     public static final Setting<Boolean> SYSTEM_CALL_FILTER_SETTING = Setting.boolSetting(
         "bootstrap.system_call_filter",

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -643,6 +643,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 PageCacheRecycler.TYPE_SETTING,
                 PluginsService.MANDATORY_SETTING,
                 BootstrapSettings.SECURITY_FILTER_BAD_DEFAULTS_SETTING,
+                BootstrapSettings.AGENT_FILE_PERMISSION_ENFORCEMENT_ENABLED,
                 BootstrapSettings.MEMORY_LOCK_SETTING,
                 BootstrapSettings.SYSTEM_CALL_FILTER_SETTING,
                 BootstrapSettings.CTRLHANDLER_SETTING,

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -201,6 +201,7 @@ import org.opensearch.indices.replication.checkpoint.RemoteStorePublishMergedSeg
 import org.opensearch.indices.store.IndicesStore;
 import org.opensearch.ingest.IngestService;
 import org.opensearch.ingest.SystemIngestPipelineCache;
+import org.opensearch.javaagent.bootstrap.AgentPolicy;
 import org.opensearch.monitor.MonitorService;
 import org.opensearch.monitor.NodeRuntimeMetrics;
 import org.opensearch.monitor.fs.FsHealthService;
@@ -698,6 +699,14 @@ public class Node implements Closeable {
             );
             threadPool.registerClusterSettingsListeners(settingsModule.getClusterSettings());
             scriptModule.registerClusterSettingsListeners(scriptService, settingsModule.getClusterSettings());
+            AgentPolicy.setFilePermissionEnforcementEnabled(
+                settingsModule.getClusterSettings().get(BootstrapSettings.AGENT_FILE_PERMISSION_ENFORCEMENT_ENABLED)
+            );
+            settingsModule.getClusterSettings()
+                .addSettingsUpdateConsumer(
+                    BootstrapSettings.AGENT_FILE_PERMISSION_ENFORCEMENT_ENABLED,
+                    AgentPolicy::setFilePermissionEnforcementEnabled
+                );
             final NetworkService networkService = new NetworkService(
                 getCustomNameResolvers(pluginsService.filterPlugins(DiscoveryPlugin.class))
             );

--- a/server/src/test/java/org/opensearch/bootstrap/BootstrapSettingsTests.java
+++ b/server/src/test/java/org/opensearch/bootstrap/BootstrapSettingsTests.java
@@ -32,16 +32,38 @@
 
 package org.opensearch.bootstrap;
 
+import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class BootstrapSettingsTests extends OpenSearchTestCase {
 
     public void testDefaultSettings() {
         assertTrue(BootstrapSettings.SECURITY_FILTER_BAD_DEFAULTS_SETTING.get(Settings.EMPTY));
+        assertTrue(BootstrapSettings.AGENT_FILE_PERMISSION_ENFORCEMENT_ENABLED.get(Settings.EMPTY));
         assertFalse(BootstrapSettings.MEMORY_LOCK_SETTING.get(Settings.EMPTY));
         assertTrue(BootstrapSettings.SYSTEM_CALL_FILTER_SETTING.get(Settings.EMPTY));
         assertTrue(BootstrapSettings.CTRLHANDLER_SETTING.get(Settings.EMPTY));
+    }
+
+    public void testAgentFilePermissionEnforcementSettingIsDynamicSensitiveClusterSetting() {
+        assertTrue(BootstrapSettings.AGENT_FILE_PERMISSION_ENFORCEMENT_ENABLED.isDynamic());
+        assertTrue(BootstrapSettings.AGENT_FILE_PERMISSION_ENFORCEMENT_ENABLED.isSensitive());
+        assertTrue(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS.contains(BootstrapSettings.AGENT_FILE_PERMISSION_ENFORCEMENT_ENABLED));
+    }
+
+    public void testAgentFilePermissionEnforcementSettingUpdateConsumer() {
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        AtomicBoolean settingValue = new AtomicBoolean(BootstrapSettings.AGENT_FILE_PERMISSION_ENFORCEMENT_ENABLED.get(Settings.EMPTY));
+        clusterSettings.addSettingsUpdateConsumer(BootstrapSettings.AGENT_FILE_PERMISSION_ENFORCEMENT_ENABLED, settingValue::set);
+
+        clusterSettings.applySettings(
+            Settings.builder().put(BootstrapSettings.AGENT_FILE_PERMISSION_ENFORCEMENT_ENABLED.getKey(), false).build()
+        );
+
+        assertFalse(settingValue.get());
     }
 
 }


### PR DESCRIPTION
## Summary

Adds a dynamic, sensitive cluster setting to control java-agent `FilePermission` enforcement:

- `plugins.security.agent.enforce_file_permissions` defaults to `true`
- the setting is registered as a built-in cluster setting and wired into `AgentPolicy`
- file-related agent interceptors consult the toggle before enforcing `FilePermission`
- test JVMs now pass `jacoco.dir` so JaCoCo shutdown writes remain covered by the test policy when legacy stream interception is enabled

This is stacked on `fix/agent-fileinputstream-instrumentation` so the PR shows the toggle separately from the FileInputStream/FileOutputStream instrumentation work.

## Validation

- `./gradlew :libs:opensearch-agent-sm:agent:test --tests org.opensearch.javaagent.FileInterceptorIntegTests`
- `./gradlew :server:test --tests org.opensearch.bootstrap.BootstrapSettingsTests`
- `./gradlew spotlessApply`
