### PR TITLE
Replace deprecated AccessController in core libraries

### DIFF
--- a/libs/common/build.gradle
+++ b/libs/common/build.gradle
@@ -33,6 +33,7 @@ dependencies {
   testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
   testImplementation "junit:junit:${versions.junit}"
   testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
+  testImplementation project(":libs:agent-sm:agent-policy")
 
   testImplementation(project(":test:framework")) {
     exclude group: 'org.opensearch', module: 'opensearch-common'

--- a/libs/common/src/test/java/org/opensearch/common/annotation/processor/CompilerSupport.java
+++ b/libs/common/src/test/java/org/opensearch/common/annotation/processor/CompilerSupport.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.common.annotation.processor;
 
+import org.opensearch.secure_sm.AccessController;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -30,8 +31,6 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -44,7 +43,6 @@ interface CompilerSupport {
         return compileWithPackage(outputDirectory, ApiAnnotationProcessorTests.class.getPackageName(), name, names);
     }
 
-    @SuppressWarnings("removal")
     default CompilerResult compileWithPackage(Path outputDirectory, String pck, String name, String... names) {
         final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         final DiagnosticCollector<JavaFileObject> collector = new DiagnosticCollector<>();
@@ -65,7 +63,7 @@ interface CompilerSupport {
             );
             task.setProcessors(Collections.singleton(new ApiAnnotationProcessor()));
 
-            if (AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> task.call())) {
+            if (AccessController.doPrivileged(task::call)) {
                 return new Success(collector.getDiagnostics());
             } else {
                 return new Failure(collector.getDiagnostics());

--- a/libs/nio/build.gradle
+++ b/libs/nio/build.gradle
@@ -32,6 +32,7 @@ apply plugin: 'opensearch.publish'
 
 dependencies {
   api project(':libs:opensearch-common')
+  implementation project(':libs:agent-sm:agent-policy')
 
   testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
   testImplementation "junit:junit:${versions.junit}"

--- a/libs/nio/src/main/java/org/opensearch/nio/ServerChannelContext.java
+++ b/libs/nio/src/main/java/org/opensearch/nio/ServerChannelContext.java
@@ -33,6 +33,7 @@
 package org.opensearch.nio;
 
 import org.opensearch.common.concurrent.CompletableContext;
+import org.opensearch.secure_sm.AccessController;
 
 import java.io.IOException;
 import java.net.BindException;
@@ -40,9 +41,6 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -129,18 +127,13 @@ public class ServerChannelContext extends ChannelContext<ServerSocketChannel> {
         socket.setReuseAddress(config.tcpReuseAddress());
     }
 
-    @SuppressWarnings("removal")
     protected static SocketChannel accept(ServerSocketChannel serverSocketChannel) throws IOException {
-        try {
-            assert serverSocketChannel.isBlocking() == false;
-            SocketChannel channel = AccessController.doPrivileged((PrivilegedExceptionAction<SocketChannel>) serverSocketChannel::accept);
-            if (serverSocketChannel.isBlocking() == true) {
-                channel.close();
-                throw new AssertionError("serverSocketChannel is blocking.");
-            }
-            return channel;
-        } catch (PrivilegedActionException e) {
-            throw (IOException) e.getCause();
+        assert serverSocketChannel.isBlocking() == false;
+        SocketChannel channel = AccessController.doPrivilegedChecked(serverSocketChannel::accept);
+        if (serverSocketChannel.isBlocking() == true) {
+            channel.close();
+            throw new AssertionError("serverSocketChannel is blocking.");
         }
+        return channel;
     }
 }

--- a/libs/nio/src/main/java/org/opensearch/nio/SocketChannelContext.java
+++ b/libs/nio/src/main/java/org/opensearch/nio/SocketChannelContext.java
@@ -36,6 +36,7 @@ import org.opensearch.common.concurrent.CompletableContext;
 import org.opensearch.common.util.net.NetUtils;
 import org.opensearch.nio.utils.ByteBufferUtils;
 import org.opensearch.nio.utils.ExceptionsHelper;
+import org.opensearch.secure_sm.AccessController;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -44,9 +45,6 @@ import java.net.SocketOption;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SocketChannel;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.Set;
@@ -386,12 +384,7 @@ public abstract class SocketChannelContext extends ChannelContext<SocketChannel>
         }
     }
 
-    @SuppressWarnings("removal")
     private static void connect(SocketChannel socketChannel, InetSocketAddress remoteAddress) throws IOException {
-        try {
-            AccessController.doPrivileged((PrivilegedExceptionAction<Boolean>) () -> socketChannel.connect(remoteAddress));
-        } catch (PrivilegedActionException e) {
-            throw (IOException) e.getCause();
-        }
+        AccessController.doPrivilegedChecked(() -> socketChannel.connect(remoteAddress));
     }
 }

--- a/libs/plugin-classloader/build.gradle
+++ b/libs/plugin-classloader/build.gradle
@@ -30,6 +30,10 @@
 
 test.enabled = false
 
+dependencies {
+  implementation project(':libs:agent-sm:agent-policy')
+}
+
 // test depend on ES core...
 disableTasks('forbiddenApisMain')
 jarHell.enabled = false

--- a/libs/plugin-classloader/src/main/java/org/opensearch/plugin/classloader/ExtendedPluginsClassLoader.java
+++ b/libs/plugin-classloader/src/main/java/org/opensearch/plugin/classloader/ExtendedPluginsClassLoader.java
@@ -32,8 +32,8 @@
 
 package org.opensearch.plugin.classloader;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
+import org.opensearch.secure_sm.AccessController;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -65,10 +65,7 @@ public class ExtendedPluginsClassLoader extends ClassLoader {
     /**
      * Return a new classloader across the parent and extended loaders.
      */
-    @SuppressWarnings("removal")
     public static ExtendedPluginsClassLoader create(ClassLoader parent, List<ClassLoader> extendedLoaders) {
-        return AccessController.doPrivileged(
-            (PrivilegedAction<ExtendedPluginsClassLoader>) () -> new ExtendedPluginsClassLoader(parent, extendedLoaders)
-        );
+        return AccessController.doPrivileged(() -> new ExtendedPluginsClassLoader(parent, extendedLoaders));
     }
 }


### PR DESCRIPTION
## What changed

- Replace the deprecated JDK `java.security.AccessController` usage in `CompilerSupport` with OpenSearch's agent-policy replacement.
- Replace the deprecated JDK `AccessController` usage around NIO socket `connect` and `accept` operations with `doPrivilegedChecked`.
- Replace the deprecated JDK `AccessController` usage used to construct `ExtendedPluginsClassLoader`.
- Remove the obsolete `PrivilegedAction` cast and `removal` suppression.
- Declare direct agent-policy dependencies for `opensearch-common` tests, NIO, and the plugin classloader.

## Why

Java 25 reports `java.security.AccessController` as deprecated. OpenSearch already provides `org.opensearch.secure_sm.AccessController` for privileged boundaries enforced by the Java agent.

The compiler, NIO, and plugin-classloader operations remain inside privileged boundaries while avoiding the deprecated JDK API. The NIO migration also propagates `IOException` directly instead of wrapping it in `PrivilegedActionException` and casting its cause.

## Validation

Run with Amazon Corretto JDK 25 and `-Pcrypto.standard=FIPS-140-3`:

- `./gradlew :libs:opensearch-common:forbiddenApisTest :libs:opensearch-common:test --tests 'org.opensearch.common.annotation.processor.ApiAnnotationProcessorTests' :libs:opensearch-common:spotlessCheck -Pcrypto.standard=FIPS-140-3`
- `./gradlew :libs:opensearch-common:check -Pcrypto.standard=FIPS-140-3`
- `./gradlew :libs:opensearch-nio:check -Pcrypto.standard=FIPS-140-3 --rerun-tasks`
- `./gradlew :libs:opensearch-plugin-classloader:check -Pcrypto.standard=FIPS-140-3 --rerun-tasks`
- `./gradlew :distribution:archives:integ-test-zip:assemble -Pcrypto.standard=FIPS-140-3`
