### PR TITLE
Add intrinsic setting property

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/AbstractScopedSettings.java
@@ -785,6 +785,15 @@ public abstract class AbstractScopedSettings {
     }
 
     /**
+     * Returns <code>true</code> if the setting for the given key is intrinsic to the cluster where it is configured and should not be
+     * replicated to another cluster. Otherwise <code>false</code>.
+     */
+    public boolean isIntrinsicSetting(String key) {
+        final Setting<?> setting = get(key);
+        return setting != null && setting.isIntrinsic();
+    }
+
+    /**
      * Returns a settings object that contains all settings that are not
      * already set in the given source. The diff contains either the default value for each
      * setting or the settings value in the given default settings.

--- a/server/src/main/java/org/opensearch/common/settings/Setting.java
+++ b/server/src/main/java/org/opensearch/common/settings/Setting.java
@@ -185,7 +185,13 @@ public class Setting<T> implements ToXContentObject {
          * different policies for these settings. In practice the security plugin will
          * require higher privileges for modifying sensitive settings.
          */
-        Sensitive
+        Sensitive,
+
+        /**
+         * Marks a setting as intrinsic to the cluster where it is configured. Intrinsic settings describe local cluster
+         * characteristics and should not be replicated to another cluster.
+         */
+        Intrinsic
     }
 
     private final Key key;
@@ -378,6 +384,14 @@ public class Setting<T> implements ToXContentObject {
      */
     public final boolean isSensitive() {
         return properties.contains(Property.Sensitive);
+    }
+
+    /**
+     * Returns <code>true</code> if this setting is intrinsic to the cluster where it is configured and should not be replicated to
+     * another cluster.
+     */
+    public final boolean isIntrinsic() {
+        return properties.contains(Property.Intrinsic);
     }
 
     public final boolean isInternalIndex() {

--- a/server/src/test/java/org/opensearch/common/settings/ScopedSettingsTests.java
+++ b/server/src/test/java/org/opensearch/common/settings/ScopedSettingsTests.java
@@ -813,6 +813,24 @@ public class ScopedSettingsTests extends OpenSearchTestCase {
         assertTrue(settings.isUnmodifiableOnRestoreSetting("foo.group.key"));
     }
 
+    public void testIsIntrinsic() {
+        ClusterSettings settings = new ClusterSettings(
+            Settings.EMPTY,
+            Set.of(
+                Setting.intSetting("foo.int", 1, Property.Intrinsic, Property.NodeScope),
+                Setting.groupSetting("foo.group.", Property.Intrinsic, Property.NodeScope),
+                Setting.affixKeySetting("foo.affix.", "value", key -> Setting.simpleString(key, Property.Intrinsic, Property.NodeScope)),
+                Setting.simpleString("foo.replicable", Property.NodeScope)
+            )
+        );
+
+        assertTrue(settings.isIntrinsicSetting("foo.int"));
+        assertTrue(settings.isIntrinsicSetting("foo.group.key"));
+        assertTrue(settings.isIntrinsicSetting("foo.affix.namespace.value"));
+        assertFalse(settings.isIntrinsicSetting("foo.replicable"));
+        assertFalse(settings.isIntrinsicSetting("foo.unknown"));
+    }
+
     public void testDiff() throws IOException {
         Setting<Integer> fooBarBaz = Setting.intSetting("foo.bar.baz", 1, Property.NodeScope);
         Setting<Integer> fooBar = Setting.intSetting("foo.bar", 1, Property.Dynamic, Property.NodeScope);


### PR DESCRIPTION
## Summary

- add `Setting.Property.Intrinsic` for settings that describe cluster-local characteristics and should not be replicated to another cluster
- expose `Setting#isIntrinsic()` and `AbstractScopedSettings#isIntrinsicSetting(String)`
- cover exact, group, and affix settings, including the default behavior for unmarked and unknown settings

## Motivation

Cross-cluster consumers currently need to maintain their own setting blocklists. For example, cross-cluster replication manually excludes several index settings when synchronizing leader metadata to a follower. A shared core property lets setting owners declare this behavior alongside the setting definition and gives replication or migration consumers a consistent lookup mechanism.

Settings without the property remain eligible for sharing between clusters. This PR establishes the core contract only; classification of existing settings and adoption by individual replication consumers can follow separately.

## Validation

- `./gradlew :server:test --tests org.opensearch.common.settings.ScopedSettingsTests -Pcrypto.standard=FIPS-140-3`
- `./gradlew :server:spotlessJavaCheck -Pcrypto.standard=FIPS-140-3`
- `./gradlew :server:precommit -Pcrypto.standard=FIPS-140-3`