### PR TITLE
Track local all-indices request provenance

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthRequest.java
@@ -37,6 +37,7 @@ import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.IndicesRequest;
 import org.opensearch.action.support.ActiveShardCount;
 import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.action.support.LocalAllIndicesRequest;
 import org.opensearch.action.support.clustermanager.ClusterManagerNodeReadRequest;
 import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.common.Priority;
@@ -57,9 +58,13 @@ import static org.opensearch.action.ValidateActions.addValidationError;
  * @opensearch.api
  */
 @PublicApi(since = "1.0.0")
-public class ClusterHealthRequest extends ClusterManagerNodeReadRequest<ClusterHealthRequest> implements IndicesRequest.Replaceable {
+public class ClusterHealthRequest extends ClusterManagerNodeReadRequest<ClusterHealthRequest>
+    implements
+        IndicesRequest.Replaceable,
+        LocalAllIndicesRequest {
 
     private String[] indices;
+    private boolean derivedFromLocalAllIndices;
     private String awarenessAttribute;
     private IndicesOptions indicesOptions = IndicesOptions.lenientExpandHidden();
     private TimeValue timeout = new TimeValue(30, TimeUnit.SECONDS);
@@ -167,6 +172,16 @@ public class ClusterHealthRequest extends ClusterManagerNodeReadRequest<ClusterH
     public ClusterHealthRequest indices(String... indices) {
         this.indices = indices;
         return this;
+    }
+
+    @Override
+    public void markAsDerivedFromLocalAllIndices() {
+        derivedFromLocalAllIndices = true;
+    }
+
+    @Override
+    public boolean isDerivedFromLocalAllIndices() {
+        return derivedFromLocalAllIndices;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthRequest.java
@@ -123,6 +123,9 @@ public class ClusterHealthRequest extends ClusterManagerNodeReadRequest<ClusterH
         if (in.getVersion().onOrAfter(Version.V_2_17_0)) {
             applyLevelAtTransportLayer = in.readBoolean();
         }
+        if (in.getVersion().onOrAfter(Version.V_3_8_0)) {
+            derivedFromLocalAllIndices = in.readBoolean();
+        }
     }
 
     @Override
@@ -160,6 +163,9 @@ public class ClusterHealthRequest extends ClusterManagerNodeReadRequest<ClusterH
         }
         if (out.getVersion().onOrAfter(Version.V_2_17_0)) {
             out.writeBoolean(applyLevelAtTransportLayer);
+        }
+        if (out.getVersion().onOrAfter(Version.V_3_8_0)) {
+            out.writeBoolean(derivedFromLocalAllIndices);
         }
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/stats/IndicesStatsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/stats/IndicesStatsRequest.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.action.admin.indices.stats;
 
+import org.opensearch.action.support.LocalAllIndicesRequest;
 import org.opensearch.action.support.broadcast.BroadcastRequest;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -54,9 +55,10 @@ import java.util.Map;
  * @opensearch.api
  */
 @PublicApi(since = "1.0.0")
-public class IndicesStatsRequest extends BroadcastRequest<IndicesStatsRequest> {
+public class IndicesStatsRequest extends BroadcastRequest<IndicesStatsRequest> implements LocalAllIndicesRequest {
 
     private CommonStatsFlags flags = new CommonStatsFlags();
+    private boolean derivedFromLocalAllIndices;
 
     public IndicesStatsRequest() {
         super((String[]) null);
@@ -88,6 +90,16 @@ public class IndicesStatsRequest extends BroadcastRequest<IndicesStatsRequest> {
      */
     public CommonStatsFlags flags() {
         return flags;
+    }
+
+    @Override
+    public void markAsDerivedFromLocalAllIndices() {
+        derivedFromLocalAllIndices = true;
+    }
+
+    @Override
+    public boolean isDerivedFromLocalAllIndices() {
+        return derivedFromLocalAllIndices;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/action/admin/indices/stats/IndicesStatsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/stats/IndicesStatsRequest.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.action.admin.indices.stats;
 
+import org.opensearch.Version;
 import org.opensearch.action.support.LocalAllIndicesRequest;
 import org.opensearch.action.support.broadcast.BroadcastRequest;
 import org.opensearch.common.annotation.PublicApi;
@@ -67,6 +68,9 @@ public class IndicesStatsRequest extends BroadcastRequest<IndicesStatsRequest> i
     public IndicesStatsRequest(StreamInput in) throws IOException {
         super(in);
         flags = new CommonStatsFlags(in);
+        if (in.getVersion().onOrAfter(Version.V_3_8_0)) {
+            derivedFromLocalAllIndices = in.readBoolean();
+        }
     }
 
     /**
@@ -313,6 +317,9 @@ public class IndicesStatsRequest extends BroadcastRequest<IndicesStatsRequest> i
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         flags.writeTo(out);
+        if (out.getVersion().onOrAfter(Version.V_3_8_0)) {
+            out.writeBoolean(derivedFromLocalAllIndices);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/support/LocalAllIndicesRequest.java
+++ b/server/src/main/java/org/opensearch/action/support/LocalAllIndicesRequest.java
@@ -18,8 +18,9 @@ import java.util.Arrays;
  *
  * Coordinating actions can resolve an all-indices expression into concrete index names before
  * issuing child requests. This marker lets authorization plugins distinguish those derived
- * requests from requests that explicitly named the same concrete indices. Implementations must
- * not serialize the marker.
+ * requests from requests that explicitly named the same concrete indices. Implementations
+ * propagate the marker between cluster nodes; authorization code must trust it only when Core
+ * marked the local request or it arrived over a trusted node connection.
  *
  * @opensearch.internal
  */

--- a/server/src/main/java/org/opensearch/action/support/LocalAllIndicesRequest.java
+++ b/server/src/main/java/org/opensearch/action/support/LocalAllIndicesRequest.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.support;
+
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.common.annotation.InternalApi;
+
+import java.util.Arrays;
+
+/**
+ * Local-only provenance for a request that was derived from an all-indices expression.
+ *
+ * Coordinating actions can resolve an all-indices expression into concrete index names before
+ * issuing child requests. This marker lets authorization plugins distinguish those derived
+ * requests from requests that explicitly named the same concrete indices. Implementations must
+ * not serialize the marker.
+ *
+ * @opensearch.internal
+ */
+@InternalApi
+public interface LocalAllIndicesRequest {
+
+    /**
+     * Marks this request as derived from an all-indices expression.
+     */
+    void markAsDerivedFromLocalAllIndices();
+
+    /**
+     * Returns whether this request was derived from an all-indices expression.
+     */
+    boolean isDerivedFromLocalAllIndices();
+
+    /**
+     * Marks {@code request} when {@code originalIndices} targets all local indices.
+     */
+    static void markIfAllIndices(LocalAllIndicesRequest request, String[] originalIndices) {
+        if (isAllIndices(originalIndices)) {
+            request.markAsDerivedFromLocalAllIndices();
+        }
+    }
+
+    private static boolean isAllIndices(String[] indices) {
+        return IndexNameExpressionResolver.isAllIndices(indices == null ? null : Arrays.asList(indices))
+            || (indices != null && indices.length == 1 && "*".equals(indices[0]));
+    }
+}

--- a/server/src/main/java/org/opensearch/action/support/LocalAllIndicesRequestContext.java
+++ b/server/src/main/java/org/opensearch/action/support/LocalAllIndicesRequestContext.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.support;
+
+import org.opensearch.common.annotation.InternalApi;
+import org.opensearch.common.util.concurrent.ThreadContext;
+
+/**
+ * Local proof that Core marked a request as derived from an all-indices expression.
+ *
+ * @opensearch.internal
+ */
+@InternalApi
+public final class LocalAllIndicesRequestContext {
+
+    private static final String TRANSIENT_KEY = LocalAllIndicesRequestContext.class.getName();
+    private static final Object MARKER = new Object();
+
+    private LocalAllIndicesRequestContext() {}
+
+    /**
+     * Runs an action with local Core provenance when {@code request} is marked as derived from all indices.
+     */
+    public static void runWithContext(ThreadContext threadContext, LocalAllIndicesRequest request, Runnable action) {
+        if (request.isDerivedFromLocalAllIndices() == false || isMarked(threadContext)) {
+            action.run();
+            return;
+        }
+
+        try (ThreadContext.StoredContext ignored = threadContext.newStoredContext(false)) {
+            threadContext.putTransient(TRANSIENT_KEY, MARKER);
+            action.run();
+        }
+    }
+
+    /**
+     * Returns whether Core marked the current local request.
+     */
+    public static boolean isMarked(ThreadContext threadContext) {
+        return threadContext.getTransient(TRANSIENT_KEY) == MARKER;
+    }
+
+}

--- a/server/src/main/java/org/opensearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
+++ b/server/src/main/java/org/opensearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
@@ -39,6 +39,8 @@ import org.opensearch.action.NoShardAvailableActionException;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.action.support.LocalAllIndicesRequest;
+import org.opensearch.action.support.LocalAllIndicesRequestContext;
 import org.opensearch.action.support.TransportActions;
 import org.opensearch.action.support.TransportIndicesResolvingAction;
 import org.opensearch.action.support.broadcast.BroadcastRequest;
@@ -427,36 +429,39 @@ public abstract class TransportBroadcastByNodeAction<
                 if (task != null) {
                     nodeRequest.setParentTask(clusterService.localNode().getId(), task.getId());
                 }
-                TransportRequestOptions transportRequestOptions = TransportRequestOptions.EMPTY;
-                if (request != null && request.timeout() != null) {
-                    transportRequestOptions = TransportRequestOptions.builder().withTimeout(request.timeout()).build();
-                }
-                transportService.sendRequest(
-                    node,
-                    transportNodeBroadcastAction,
+                final TransportRequestOptions transportRequestOptions = request != null && request.timeout() != null
+                    ? TransportRequestOptions.builder().withTimeout(request.timeout()).build()
+                    : TransportRequestOptions.EMPTY;
+                LocalAllIndicesRequestContext.runWithContext(
+                    threadPool.getThreadContext(),
                     nodeRequest,
-                    transportRequestOptions,
-                    new TransportResponseHandler<NodeResponse>() {
-                        @Override
-                        public NodeResponse read(StreamInput in) throws IOException {
-                            return new NodeResponse(in);
-                        }
+                    () -> transportService.sendRequest(
+                        node,
+                        transportNodeBroadcastAction,
+                        nodeRequest,
+                        transportRequestOptions,
+                        new TransportResponseHandler<NodeResponse>() {
+                            @Override
+                            public NodeResponse read(StreamInput in) throws IOException {
+                                return new NodeResponse(in);
+                            }
 
-                        @Override
-                        public void handleResponse(NodeResponse response) {
-                            onNodeResponse(node, nodeIndex, response);
-                        }
+                            @Override
+                            public void handleResponse(NodeResponse response) {
+                                onNodeResponse(node, nodeIndex, response);
+                            }
 
-                        @Override
-                        public void handleException(TransportException exp) {
-                            onNodeFailure(node, nodeIndex, exp);
-                        }
+                            @Override
+                            public void handleException(TransportException exp) {
+                                onNodeFailure(node, nodeIndex, exp);
+                            }
 
-                        @Override
-                        public String executor() {
-                            return ThreadPool.Names.SAME;
+                            @Override
+                            public String executor() {
+                                return ThreadPool.Names.SAME;
+                            }
                         }
-                    }
+                    )
                 );
             } catch (Exception e) {
                 onNodeFailure(node, nodeIndex, e);
@@ -707,7 +712,7 @@ public abstract class TransportBroadcastByNodeAction<
      *
      * @opensearch.internal
      */
-    public class NodeRequest extends TransportRequest implements IndicesRequest {
+    public class NodeRequest extends TransportRequest implements IndicesRequest, LocalAllIndicesRequest {
         private String nodeId;
 
         private List<ShardRouting> shards;
@@ -743,6 +748,19 @@ public abstract class TransportBroadcastByNodeAction<
         @Override
         public IndicesOptions indicesOptions() {
             return indicesLevelRequest.indicesOptions();
+        }
+
+        @Override
+        public void markAsDerivedFromLocalAllIndices() {
+            if (indicesLevelRequest instanceof LocalAllIndicesRequest) {
+                ((LocalAllIndicesRequest) indicesLevelRequest).markAsDerivedFromLocalAllIndices();
+            }
+        }
+
+        @Override
+        public boolean isDerivedFromLocalAllIndices() {
+            return indicesLevelRequest instanceof LocalAllIndicesRequest
+                && ((LocalAllIndicesRequest) indicesLevelRequest).isDerivedFromLocalAllIndices();
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterHealthAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterHealthAction.java
@@ -35,6 +35,7 @@ package org.opensearch.rest.action.admin.cluster;
 import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.opensearch.action.support.ActiveShardCount;
 import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.action.support.LocalAllIndicesRequest;
 import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.common.Priority;
 import org.opensearch.common.logging.DeprecationLogger;
@@ -82,6 +83,7 @@ public class RestClusterHealthAction extends BaseRestHandler {
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         final ClusterHealthRequest clusterHealthRequest = fromRequest(request);
+        LocalAllIndicesRequest.markIfAllIndices(clusterHealthRequest, clusterHealthRequest.indices());
         return channel -> client.admin().cluster().health(clusterHealthRequest, new RestStatusToXContentListener<>(channel));
     }
 

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterHealthAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterHealthAction.java
@@ -36,6 +36,7 @@ import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.opensearch.action.support.ActiveShardCount;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.action.support.LocalAllIndicesRequest;
+import org.opensearch.action.support.LocalAllIndicesRequestContext;
 import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.common.Priority;
 import org.opensearch.common.logging.DeprecationLogger;
@@ -84,7 +85,11 @@ public class RestClusterHealthAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         final ClusterHealthRequest clusterHealthRequest = fromRequest(request);
         LocalAllIndicesRequest.markIfAllIndices(clusterHealthRequest, clusterHealthRequest.indices());
-        return channel -> client.admin().cluster().health(clusterHealthRequest, new RestStatusToXContentListener<>(channel));
+        return channel -> LocalAllIndicesRequestContext.runWithContext(
+            client.threadPool().getThreadContext(),
+            clusterHealthRequest,
+            () -> client.admin().cluster().health(clusterHealthRequest, new RestStatusToXContentListener<>(channel))
+        );
     }
 
     public static ClusterHealthRequest fromRequest(final RestRequest request) {

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestIndicesStatsAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestIndicesStatsAction.java
@@ -36,6 +36,7 @@ import org.opensearch.action.admin.indices.stats.CommonStatsFlags;
 import org.opensearch.action.admin.indices.stats.CommonStatsFlags.Flag;
 import org.opensearch.action.admin.indices.stats.IndicesStatsRequest;
 import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.action.support.LocalAllIndicesRequest;
 import org.opensearch.core.common.Strings;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.RestRequest;
@@ -160,6 +161,7 @@ public class RestIndicesStatsAction extends BaseRestHandler {
             indicesStatsRequest.includeUnloadedSegments(request.paramAsBoolean("include_unloaded_segments", false));
         }
 
+        LocalAllIndicesRequest.markIfAllIndices(indicesStatsRequest, indicesStatsRequest.indices());
         return channel -> client.admin().indices().stats(indicesStatsRequest, new RestToXContentListener<>(channel));
     }
 

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestIndicesStatsAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestIndicesStatsAction.java
@@ -37,6 +37,7 @@ import org.opensearch.action.admin.indices.stats.CommonStatsFlags.Flag;
 import org.opensearch.action.admin.indices.stats.IndicesStatsRequest;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.action.support.LocalAllIndicesRequest;
+import org.opensearch.action.support.LocalAllIndicesRequestContext;
 import org.opensearch.core.common.Strings;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.RestRequest;
@@ -162,7 +163,11 @@ public class RestIndicesStatsAction extends BaseRestHandler {
         }
 
         LocalAllIndicesRequest.markIfAllIndices(indicesStatsRequest, indicesStatsRequest.indices());
-        return channel -> client.admin().indices().stats(indicesStatsRequest, new RestToXContentListener<>(channel));
+        return channel -> LocalAllIndicesRequestContext.runWithContext(
+            client.threadPool().getThreadContext(),
+            indicesStatsRequest,
+            () -> client.admin().indices().stats(indicesStatsRequest, new RestToXContentListener<>(channel))
+        );
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestIndicesAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestIndicesAction.java
@@ -47,6 +47,7 @@ import org.opensearch.action.pagination.IndexPaginationStrategy;
 import org.opensearch.action.pagination.PageToken;
 import org.opensearch.action.support.GroupedActionListener;
 import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.action.support.LocalAllIndicesRequest;
 import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.cluster.health.ClusterIndexHealth;
 import org.opensearch.cluster.metadata.IndexMetadata;
@@ -222,6 +223,7 @@ public class RestIndicesAction extends AbstractListAction {
                                             indicesToBeQueried,
                                             subRequestIndicesOptions,
                                             includeUnloadedSegments,
+                                            indices,
                                             client,
                                             ActionListener.wrap(groupedListener::onResponse, groupedListener::onFailure)
                                         );
@@ -232,6 +234,7 @@ public class RestIndicesAction extends AbstractListAction {
                                         subRequestIndicesOptions,
                                         local,
                                         clusterManagerNodeTimeout,
+                                        indices,
                                         client,
                                         ActionListener.wrap(groupedListener::onResponse, groupedListener::onFailure)
                                     );
@@ -313,6 +316,7 @@ public class RestIndicesAction extends AbstractListAction {
         final IndicesOptions indicesOptions,
         final boolean local,
         final TimeValue clusterManagerNodeTimeout,
+        final String[] originalIndices,
         final NodeClient client,
         final ActionListener<ClusterHealthResponse> listener
     ) {
@@ -322,6 +326,7 @@ public class RestIndicesAction extends AbstractListAction {
         request.indicesOptions(indicesOptions);
         request.local(local);
         request.clusterManagerNodeTimeout(clusterManagerNodeTimeout);
+        LocalAllIndicesRequest.markIfAllIndices(request, originalIndices);
 
         client.admin().cluster().health(request, listener);
     }
@@ -330,6 +335,7 @@ public class RestIndicesAction extends AbstractListAction {
         final String[] indices,
         final IndicesOptions indicesOptions,
         final boolean includeUnloadedSegments,
+        final String[] originalIndices,
         final NodeClient client,
         final ActionListener<IndicesStatsResponse> listener
     ) {
@@ -339,6 +345,7 @@ public class RestIndicesAction extends AbstractListAction {
         request.indicesOptions(indicesOptions);
         request.all();
         request.includeUnloadedSegments(includeUnloadedSegments);
+        LocalAllIndicesRequest.markIfAllIndices(request, originalIndices);
 
         client.admin().indices().stats(request, listener);
     }

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestIndicesAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestIndicesAction.java
@@ -48,6 +48,7 @@ import org.opensearch.action.pagination.PageToken;
 import org.opensearch.action.support.GroupedActionListener;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.action.support.LocalAllIndicesRequest;
+import org.opensearch.action.support.LocalAllIndicesRequestContext;
 import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.cluster.health.ClusterIndexHealth;
 import org.opensearch.cluster.metadata.IndexMetadata;
@@ -328,7 +329,11 @@ public class RestIndicesAction extends AbstractListAction {
         request.clusterManagerNodeTimeout(clusterManagerNodeTimeout);
         LocalAllIndicesRequest.markIfAllIndices(request, originalIndices);
 
-        client.admin().cluster().health(request, listener);
+        LocalAllIndicesRequestContext.runWithContext(
+            client.threadPool().getThreadContext(),
+            request,
+            () -> client.admin().cluster().health(request, listener)
+        );
     }
 
     private void sendIndicesStatsRequest(
@@ -347,7 +352,11 @@ public class RestIndicesAction extends AbstractListAction {
         request.includeUnloadedSegments(includeUnloadedSegments);
         LocalAllIndicesRequest.markIfAllIndices(request, originalIndices);
 
-        client.admin().indices().stats(request, listener);
+        LocalAllIndicesRequestContext.runWithContext(
+            client.threadPool().getThreadContext(),
+            request,
+            () -> client.admin().indices().stats(request, listener)
+        );
     }
 
     private GroupedActionListener<ActionResponse> createGroupedListener(

--- a/server/src/test/java/org/opensearch/action/support/LocalAllIndicesRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/support/LocalAllIndicesRequestTests.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.support;
+
+import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.opensearch.action.admin.indices.stats.IndicesStatsRequest;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class LocalAllIndicesRequestTests extends OpenSearchTestCase {
+
+    public void testMarksAllIndicesExpressions() {
+        for (String[] indices : new String[][] { null, new String[0], new String[] { "_all" }, new String[] { "*" } }) {
+            ClusterHealthRequest request = new ClusterHealthRequest();
+
+            LocalAllIndicesRequest.markIfAllIndices(request, indices);
+
+            assertTrue(request.isDerivedFromLocalAllIndices());
+        }
+    }
+
+    public void testDoesNotMarkExplicitIndicesExpressions() {
+        for (String[] indices : new String[][] {
+            new String[] { "index" },
+            new String[] { "index-*" },
+            new String[] { "index", "other" } }) {
+            IndicesStatsRequest request = new IndicesStatsRequest();
+
+            LocalAllIndicesRequest.markIfAllIndices(request, indices);
+
+            assertFalse(request.isDerivedFromLocalAllIndices());
+        }
+    }
+
+    public void testMarkerIsNotSerialized() throws Exception {
+        ClusterHealthRequest request = new ClusterHealthRequest();
+        request.markAsDerivedFromLocalAllIndices();
+
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            request.writeTo(output);
+            ClusterHealthRequest copy = new ClusterHealthRequest(output.bytes().streamInput());
+
+            assertFalse(copy.isDerivedFromLocalAllIndices());
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/action/support/LocalAllIndicesRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/support/LocalAllIndicesRequestTests.java
@@ -38,13 +38,25 @@ public class LocalAllIndicesRequestTests extends OpenSearchTestCase {
         }
     }
 
-    public void testMarkerIsNotSerialized() throws Exception {
+    public void testClusterHealthMarkerIsNotSerialized() throws Exception {
         ClusterHealthRequest request = new ClusterHealthRequest();
         request.markAsDerivedFromLocalAllIndices();
 
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             request.writeTo(output);
             ClusterHealthRequest copy = new ClusterHealthRequest(output.bytes().streamInput());
+
+            assertFalse(copy.isDerivedFromLocalAllIndices());
+        }
+    }
+
+    public void testIndicesStatsMarkerIsNotSerialized() throws Exception {
+        IndicesStatsRequest request = new IndicesStatsRequest();
+        request.markAsDerivedFromLocalAllIndices();
+
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            request.writeTo(output);
+            IndicesStatsRequest copy = new IndicesStatsRequest(output.bytes().streamInput());
 
             assertFalse(copy.isDerivedFromLocalAllIndices());
         }

--- a/server/src/test/java/org/opensearch/action/support/LocalAllIndicesRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/support/LocalAllIndicesRequestTests.java
@@ -11,7 +11,11 @@ package org.opensearch.action.support;
 import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.opensearch.action.admin.indices.stats.IndicesStatsRequest;
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class LocalAllIndicesRequestTests extends OpenSearchTestCase {
 
@@ -38,7 +42,7 @@ public class LocalAllIndicesRequestTests extends OpenSearchTestCase {
         }
     }
 
-    public void testClusterHealthMarkerIsNotSerialized() throws Exception {
+    public void testClusterHealthMarkerIsSerialized() throws Exception {
         ClusterHealthRequest request = new ClusterHealthRequest();
         request.markAsDerivedFromLocalAllIndices();
 
@@ -46,11 +50,11 @@ public class LocalAllIndicesRequestTests extends OpenSearchTestCase {
             request.writeTo(output);
             ClusterHealthRequest copy = new ClusterHealthRequest(output.bytes().streamInput());
 
-            assertFalse(copy.isDerivedFromLocalAllIndices());
+            assertTrue(copy.isDerivedFromLocalAllIndices());
         }
     }
 
-    public void testIndicesStatsMarkerIsNotSerialized() throws Exception {
+    public void testIndicesStatsMarkerIsSerialized() throws Exception {
         IndicesStatsRequest request = new IndicesStatsRequest();
         request.markAsDerivedFromLocalAllIndices();
 
@@ -58,7 +62,25 @@ public class LocalAllIndicesRequestTests extends OpenSearchTestCase {
             request.writeTo(output);
             IndicesStatsRequest copy = new IndicesStatsRequest(output.bytes().streamInput());
 
-            assertFalse(copy.isDerivedFromLocalAllIndices());
+            assertTrue(copy.isDerivedFromLocalAllIndices());
         }
+    }
+
+    public void testLocalContextProofIsScopedToMarkedRequest() {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        ClusterHealthRequest request = new ClusterHealthRequest();
+        AtomicBoolean actionCalled = new AtomicBoolean();
+
+        LocalAllIndicesRequestContext.runWithContext(threadContext, request, () -> {
+            actionCalled.set(true);
+            assertFalse(LocalAllIndicesRequestContext.isMarked(threadContext));
+        });
+        assertTrue(actionCalled.get());
+
+        request.markAsDerivedFromLocalAllIndices();
+        LocalAllIndicesRequestContext.runWithContext(threadContext, request, () -> {
+            assertTrue(LocalAllIndicesRequestContext.isMarked(threadContext));
+        });
+        assertFalse(LocalAllIndicesRequestContext.isMarked(threadContext));
     }
 }

--- a/server/src/test/java/org/opensearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
+++ b/server/src/test/java/org/opensearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
@@ -37,6 +37,7 @@ import org.opensearch.OpenSearchException;
 import org.opensearch.Version;
 import org.opensearch.action.IndicesRequest;
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.LocalAllIndicesRequest;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.support.broadcast.BroadcastRequest;
 import org.opensearch.action.support.broadcast.BroadcastResponse;
@@ -128,6 +129,24 @@ public class TransportBroadcastByNodeActionTests extends OpenSearchTestCase {
 
         public Request(String... indices) {
             super(indices);
+        }
+    }
+
+    public static class MarkedRequest extends Request implements LocalAllIndicesRequest {
+        private boolean derivedFromLocalAllIndices;
+
+        public MarkedRequest(String... indices) {
+            super(indices);
+        }
+
+        @Override
+        public void markAsDerivedFromLocalAllIndices() {
+            derivedFromLocalAllIndices = true;
+        }
+
+        @Override
+        public boolean isDerivedFromLocalAllIndices() {
+            return derivedFromLocalAllIndices;
         }
     }
 
@@ -783,6 +802,20 @@ public class TransportBroadcastByNodeActionTests extends OpenSearchTestCase {
             handler.messageReceived(nodeReq, channel, null);
         }
         assertEquals("nodeOperation should run once per target node", captured.size(), action.getNodeOperationCount());
+    }
+
+    public void testNodeRequestPropagatesLocalAllIndicesMarker() {
+        MarkedRequest request = new MarkedRequest(TEST_INDEX);
+        TransportBroadcastByNodeAction<Request, Response, TransportBroadcastByNodeAction.EmptyResult>.NodeRequest nodeRequest = action.new NodeRequest(
+            "node",
+            request,
+            List.of()
+        );
+
+        assertFalse(nodeRequest.isDerivedFromLocalAllIndices());
+        nodeRequest.markAsDerivedFromLocalAllIndices();
+        assertTrue(nodeRequest.isDerivedFromLocalAllIndices());
+        assertTrue(request.isDerivedFromLocalAllIndices());
     }
 
     public void testResultAggregation() throws ExecutionException, InterruptedException {


### PR DESCRIPTION
## Summary

Add explicit provenance to index-stats and cluster-health requests so authorization plugins can distinguish child requests derived from an all-indices expression from callers that explicitly name the same concrete indices.

Core marks direct all-indices REST requests and transfers the original intent through `_list/indices` child requests. The marker is serialized for node-to-node fan-out from version 3.8.0 onward, while a ThreadContext transient proves locally originated requests.

Broadcast node requests preserve both the marker and local context across fan-out.

## Security model

The serialized marker is provenance, not authorization. Consumers must accept it only with either Core's unforgeable local transient or an authenticated node-to-node transport request. REST callers cannot set either proof.

This permits coordinating APIs to resolve all indices before issuing monitor child requests without weakening direct access controls for protected concrete indices.

## Validation

- `./gradlew :server:spotlessApply :server:test --tests 'org.opensearch.action.support.LocalAllIndicesRequestTests' :server:publishToMavenLocal -Pcrypto.standard=FIPS-140-3`
- `./gradlew :server:test --tests 'org.opensearch.action.support.broadcast.node.TransportBroadcastByNodeActionTests.testNodeRequestPropagatesLocalAllIndicesMarker' -Pcrypto.standard=FIPS-140-3`

## Coordinated drafts

- Security consumer: https://github.com/cwperks/security/pull/112
- ML Commons caller: https://github.com/cwperks/ml-commons/pull/2